### PR TITLE
Minor fixes for downstream functionality

### DIFF
--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -45,6 +45,7 @@ def schema_to_dataclass(io: Dict[str, Parameter], class_name: str, bases=(), pos
             metadata['choices'] = schema.choices
         if schema.element_choices:
             metadata['element_choices'] = schema.element_choices
+        metadata['required'] = schema.required
 
         if isinstance(schema.default, MutableSequence):
             fld = field(default_factory=default_wrapper(list, schema.default),

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -45,7 +45,13 @@ def schema_to_dataclass(io: Dict[str, Parameter], class_name: str, bases=(), pos
             metadata['choices'] = schema.choices
         if schema.element_choices:
             metadata['element_choices'] = schema.element_choices
-        metadata['required'] = schema.required
+        metadata['required'] = required = schema.required
+
+        if required and schema.default is not None:
+            raise SchemaError(
+                f"Field '{fldname}' is required but specifies a default. "
+                f"This behaviour is unsupported/ambiguous."
+            )
 
         if isinstance(schema.default, MutableSequence):
             fld = field(default_factory=default_wrapper(list, schema.default),


### PR DESCRIPTION
This PR adds two simple things:

- Fields can either be required or have a default, not both. Will raise a `SchemaError` if the default on a required field is anything other than `None`. Note that this will not catch the `required=True` and `default=None` case but there are limits to what can be done.
- Field metadata will be updated with a `required` field. This gives users a means to separate out required fields from optional fields in postprocessing (necessary for help formatting etc).