### PR TITLE
Fix (maybe?) for required fields.

### DIFF
--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -3,7 +3,7 @@ import click
 from .cargo import Parameter
 from .exceptions import SchemaError
 from dataclasses import make_dataclass, field
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, MISSING
 from collections import OrderedDict, MutableSet, MutableSequence, MutableMapping
 
 def schema_to_dataclass(io: Dict[str, Parameter], class_name: str, bases=(), post_init: Optional[Callable] =None):
@@ -53,7 +53,9 @@ def schema_to_dataclass(io: Dict[str, Parameter], class_name: str, bases=(), pos
                 f"This behaviour is unsupported/ambiguous."
             )
 
-        if isinstance(schema.default, MutableSequence):
+        if required:
+            fld = field(default=MISSING, metadata=metadata)
+        elif isinstance(schema.default, MutableSequence):
             fld = field(default_factory=default_wrapper(list, schema.default),
                         metadata=metadata)
         elif isinstance(schema.default, MutableSet):


### PR DESCRIPTION
Previously, schema defaults would be used even when a parameter is required (i.e. no default). This PR should correctly retain `MISSING` defaults - the case for required fields. This does manifest as `'???'` when printing the dataclass. This is a special string understood by OmegaConf.