### PR TITLE
Kubernetes stimela runner for python and python-ext flavoured cabs

### DIFF
--- a/stimela/backends/kubernetes/run_kube.py
+++ b/stimela/backends/kubernetes/run_kube.py
@@ -129,10 +129,11 @@ def run(cab: Cab, params: Dict[str, Any], runtime: Dict[str, Any], fqname: str,
         modulename = cab.py_module
         funcname = cab.py_function
         command_name = f'({modulename}){funcname}'
+        # LB - why is this in an if statment below? Won't it always be the case?
+        rundir = os.path.abspath(kube.run_dir)
         command = f"""
 import sys, os
-rundir = os.path.abspath('.')
-os.chdir(rundir)
+os.chdir('{rundir}')
 # sys.path.append('.')
 from {modulename} import {funcname}
 try:

--- a/stimela/backends/kubernetes/run_kube.py
+++ b/stimela/backends/kubernetes/run_kube.py
@@ -272,8 +272,6 @@ print("Return value is", repr(retval))
                     command = ["/bin/sh", "-c", command]
                 has_input = bool(input)
 
-                import pdb; pdb.set_trace()
-
                 resp = stream(kube_api.connect_get_namespaced_pod_exec, podname, namespace,
                             command=command,
                             stderr=True, stdin=has_input,

--- a/stimela/backends/kubernetes/run_kube.py
+++ b/stimela/backends/kubernetes/run_kube.py
@@ -142,6 +142,7 @@ except ImportError:
     Command = None
 if Command is not None and isinstance({funcname}, Command):
     print("invoking callable {modulename}.{funcname}() (as click command) using external interpreter")
+    {funcname} = {funcname}.callback
 else:
     print("invoking callable {modulename}.{funcname}() using external interpreter")
 retval = {funcname}({','.join(args)})

--- a/stimela/backends/native/run_native.py
+++ b/stimela/backends/native/run_native.py
@@ -157,8 +157,10 @@ except ImportError:
     Command = None
 if Command is not None and isinstance({funcname}, Command):
     print("invoking callable {modulename}.{funcname}() (as click command) using external interpreter")
+    {funcname} = {funcname}.callback
 else:
     print("invoking callable {modulename}.{funcname}() using external interpreter")
+
 retval = {funcname}({','.join(arguments)})
 print("Return value is", repr(retval))
     """

--- a/stimela/backends/native/run_native.py
+++ b/stimela/backends/native/run_native.py
@@ -26,7 +26,7 @@ class LoggerIO(TextIOBase):
     def write(self, s):
         if s != "\n":
             for line in s.rstrip().split("\n"):
-                dispatch_to_log(self.log, line, self.command_name, self.stream_name, 
+                dispatch_to_log(self.log, line, self.command_name, self.stream_name,
                                 output_wrangler=self.output_wrangler)
         return len(s)
 
@@ -59,7 +59,7 @@ def run_callable(modulename: str, funcname: str,  cab: Cab, params: Dict[str, An
 
     Args:
         modulename (str): module name to import
-        funcname (str): name of function in module to call 
+        funcname (str): name of function in module to call
         cab (Cab): cab object
         log (logger): logger to use
         subst (Optional[Dict[str, Any]]): Substitution dict for commands etc., if any.
@@ -126,7 +126,7 @@ def run_external_callable(modulename: str, funcname: str,  cab: Cab, params: Dic
 
     Args:
         modulename (str): module name to import
-        funcname (str): name of function in module to call 
+        funcname (str): name of function in module to call
         cab (Cab): cab object
         log (logger): logger to use
         subst (Optional[Dict[str, Any]]): Substitution dict for commands etc., if any.
@@ -147,7 +147,7 @@ def run_external_callable(modulename: str, funcname: str,  cab: Cab, params: Dic
                 arguments.append(f"{key}=None")
 
     # form up command string
-    command = f"""    
+    command = f"""
 import sys
 sys.path.append('.')
 from {modulename} import {funcname}
@@ -178,7 +178,7 @@ print("Return value is", repr(retval))
     else:
         interpreter = "python"
 
-    args = [interpreter, "-c", command]    
+    args = [interpreter, "-c", command]
 
     return _run_external(args, funcname, cab, params, subst, log, log_command=False)
 
@@ -207,7 +207,7 @@ def run_command(cab: Cab, params: Dict[str, Any], log: logging.Logger, subst: Op
         args = ["/bin/bash", "--rcfile", f"{venv}/bin/activate", "-c", " ".join(shlex.quote(arg) for arg in args)]
 
     log.debug(f"command line is {args}")
-    
+
     cab.reset_runtime_status()
 
     return _run_external(args, command_name, cab, params, subst, log, batch, log_command=True)
@@ -229,8 +229,8 @@ def _run_external(args, command_name, cab, params, subst, log, batch=None, log_c
     #-------------------------------------------------------
     # run command
 
-    retcode = xrun(args[0], args[1:], shell=False, log=log, 
-                output_wrangler=cab.apply_output_wranglers, 
+    retcode = xrun(args[0], args[1:], shell=False, log=log,
+                output_wrangler=cab.apply_output_wranglers,
                 return_errcode=True, command_name=command_name, log_command=log_command)
 
     # if retcode is not zero, raise error, unless cab declared itself a success (via the wrangler)

--- a/tests/stimela_tests/test_dask_storage_options.json
+++ b/tests/stimela_tests/test_dask_storage_options.json
@@ -1,9 +1,0 @@
-{
-    "key": "simon",
-    "secret": "simon123",
-    "client_kwargs": {
-        "endpoint_url": "https://minio:443",
-        "region_name": "af-cpt",
-        "verify": false
-    }
-}

--- a/tests/stimela_tests/test_dask_storage_options.yaml
+++ b/tests/stimela_tests/test_dask_storage_options.yaml
@@ -1,0 +1,8 @@
+storage_options:
+  s3://binface:
+    client_kwargs:
+      endpoint_url: https://minio:443
+      region_name: af-cpt
+      verify: false
+    key: simon
+    secret: simon123

--- a/tests/stimela_tests/test_kube.yml
+++ b/tests/stimela_tests/test_kube.yml
@@ -4,7 +4,7 @@ _include:
 cabs:
   quarticube:
     _use: cabs.quartical
-    virtual_env: 
+    virtual_env:
     image: quartical-kubetest:local
     backend: kubernetes
     command: goquartical
@@ -14,7 +14,7 @@ cabs:
         # dask cluster settings
         dask_cluster:
           name: qc-test-cluster
-          persist: true          
+          persist: true
           num_workers: 4
           cpu_limit: 4
           memory_limit: "16Gi"
@@ -24,8 +24,8 @@ cabs:
           cwd:
             path: .
           dask-storage-config:
-            path: test_dask_storage_options.json
-            dest: /.config/dask-ms/storage_options.json
+            path: test_dask_storage_options.yaml
+            dest: /.config/dask-ms/storage_options.yaml
           numba-cache:
             path: ~/.cache/numba
             mkdir: true
@@ -46,7 +46,7 @@ cabs:
         #         endpoint_url: https://minio:443
         #         region_name: af-cpt
         #         verify: false
-        
+
         # list of command to be executed inside the pod before launching the main command
         pre_commands:
           - echo $HOME
@@ -55,7 +55,7 @@ cabs:
 
 opts:
   log:
-    dir: test-logs/logs-{config.run.datetime} 
+    dir: test-logs/logs-{config.run.datetime}
     nest: 3
     symlink: logs
 
@@ -63,7 +63,7 @@ opts:
 recipe:
   name: "demo recipe"
   info: 'top level recipe definition'
-  steps: 
+  steps:
       test_qc:
         cab: quarticube
         params:
@@ -75,4 +75,4 @@ recipe:
           output.apply_p_jones_inv: false
           output.gain_directory: s3://binface/gains.qc
           output.log_directory: test-logs/logs.qc
-          output.overwrite: true        
+          output.overwrite: true


### PR DESCRIPTION
I am trying to run pfb-clean workers on a local kubernetes cluster based on [this](https://github.com/caracal-pipeline/stimela2/blob/kube/tests/stimela_tests/test_kube.yml) example. The problem is that [run_kube.py](https://github.com/caracal-pipeline/stimela2/blob/kube/stimela/backends/kubernetes/run_kube.py) does not currently implement runners for cabs with python or python-ext flavours. I had a crack at creating runners for python-ext flavoured cabs [here](https://github.com/caracal-pipeline/stimela2/blob/bff3c067a57719cd3981a87b9dd728823cff1efc/stimela/backends/kubernetes/run_kube.py#L119) but I don't think it is doing what it's supposed to. In particular, running
```
$ stimela -C run ~/software/lbstimecipes/pfbkube.yaml recipe  
```
on the recipe defined [here](https://github.com/landmanbester/lbstimecipes/blob/3fe60fa7c6deaa529a6fe903b1af96174e490c57/pfbkube.yaml#L47) results in
```
2022-07-27 11:53:34 STIMELA INFO: starting
2022-07-27 11:53:34 STIMELA INFO: clearing 34 cached config(s) from cache
2022-07-27 11:53:34 STIMELA INFO: loading configuration
2022-07-27 11:53:35 STIMELA INFO: no user-supplied configuration files given, using defaults
2022-07-27 11:53:35 STIMELA INFO: available backends: kubernetes native
2022-07-27 11:53:35 STIMELA INFO: default backend is native
2022-07-27 11:53:35 STIMELA INFO: saving config dependencies to ./stimela.config.deps
2022-07-27 11:53:35 STIMELA INFO: loading recipe/config /home/bester/software/lbstimecipes/pfbkube.yaml
2022-07-27 11:53:36 STIMELA INFO: /home/bester/software/lbstimecipes/pfbkube.yaml contains the following recipe sections: 'recipe'
2022-07-27 11:53:36 STIMELA INFO: selected recipe is 'recipe'
2022-07-27 11:53:36 STIMELA INFO: pre-validating the recipe
2022-07-27 11:53:37 STIMELA INFO: will run the following recipe steps:
2022-07-27 11:53:37 STIMELA INFO:     test_init
2022-07-27 11:53:37 STIMELA INFO: saved recipe dependencies to test-logs/logs-20220727-115335/stimela.recipe.deps
2022-07-27 11:53:37 STIMELA.recipe INFO: ### validated inputs
2022-07-27 11:53:37 STIMELA.recipe INFO: recipe 'recipe':
2022-07-27 11:53:37 STIMELA.recipe INFO: running recipe 'recipe'
2022-07-27 11:53:37 STIMELA.recipe INFO: processing step 'test_init'
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO: ### validated inputs
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO: cab test_init:
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   host_address = pfb-test-cluster:8786
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   scheduler = distributed
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   ms = s3://pfb-bucket/ms1_primary_subset.zarr
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   output_filename = s3://pfb-bucket/test
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   overwrite = True
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   nband = 4
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   data_column = DATA
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   weight_column = WEIGHT_SPECTRUM
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   sigma_column = SIGMA_SPECTRUM
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   flag_column = FLAG
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   gain_term = NET
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   product = I
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   utimes_per_chunk = -1
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   group_by_field = True
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   group_by_ddid = True
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   group_by_scan = True
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   precision = double
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   bda_decorr = 1.0
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO:   max_field_of_view = 3.0
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO: persistent dask cluster pfb-test-cluster appears to be up
2022-07-27 11:53:37 STIMELA.recipe.test_init INFO: starting pod recipe--test--init--0308da3e6ce044a08442b22ae1b035cb for (pfb.workers.init)init
2022-07-27 11:53:39 STIMELA.recipe.test_init INFO:   pod started after 0:00:02
2022-07-27 11:53:39 STIMELA.recipe.test_init INFO: running (pfb.workers.init)init in pod recipe--test--init--0308da3e6ce044a08442b22ae1b035cb
# fatal: not a git repository (or any of the parent directories): .git
# fatal: not a git repository (or any of the parent directories): .git
# invoking callable pfb.workers.init.init() (as click command) using external interpreter
# Traceback (most recent call last):
#   File "<string>", line 14, in <module>
#   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1130, in __call__
#     return self.main(*args, **kwargs)
#   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1054, in main
#     with self.make_context(prog_name, args, **extra) as ctx:
#   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 915, in make_context
#     ctx = self.context_class(
# TypeError: __init__() got an unexpected keyword argument 'host_address'
2022-07-27 11:53:44 STIMELA.recipe.test_init ERROR: kubernetes invocation of (pfb.workers.init)init failed after 0:00:06
2022-07-27 11:53:44 STIMELA.recipe.test_init INFO: deleting pod recipe--test--init--0308da3e6ce044a08442b22ae1b035cb
2022-07-27 11:53:44 STIMELA ERROR: error running step 'test_init'
error running step 'test_init'
├── (pfb.workers.init)init returns error code 1 after 0:00:06
└── Traceback:
    ├──   File "/home/bester/software/stimela2/stimela/kitchen/recipe.py", line 830, in loop_worker
    │       step_params = step.run(subst=subst.copy())  # make a copy of the subst dict since recipe might modify
    ├──   File "/home/bester/software/stimela2/stimela/kitchen/step.py", line 333, in run
    │       runners.run_cab(self, params, backend=backend, subst=subst, batch=batch)
    ├──   File "/home/bester/software/stimela2/stimela/kitchen/runners.py", line 14, in run_cab
    │       return backend.run(cab, runtime=runtime, params=params, log=log, subst=subst, batch=batch, fqname=step.fqname)
    └──   File "/home/bester/software/stimela2/stimela/backends/kubernetes/run_kube.py", line 346, in run
            raise StimelaCabRuntimeError(f"{command_name} returns error code {retcode} after {elapsed()}")
```
The worker I am trying to invoke definitely takes ```host_address``` as a parameter
```
$  pfb init --help                                                                                                                                                                                           1 ↵
Usage: pfb init [OPTIONS]

  Create a dirty image, psf and weights from a list of measurement sets. MFS
  images are written out in units of Jy/beam. By default only the MFS images
  are converted to fits files. Set the --fits-cubes flag to also produce fits
  cubes.

  If a host address is provided the computation can be distributed over
  imaging band and row. When using a distributed scheduler both mem-limit and
  nthreads is per node and have to be specified.

  When using a local cluster, mem-limit and nthreads refer to the global
  memory and threads available, respectively. All available resources are used
  by default.

  On a local cluster, the default is to use:

      nworkers = nband     nthreads-per-worker = 1

  They have to be specified in ~.config/dask/jobqueue.yaml in the distributed
  case.

  if LocalCluster:     nvthreads = nthreads//(nworkers*nthreads_per_worker)
  else:     nvthreads = nthreads//nthreads-per-worker

  where nvthreads refers to the number of threads used to scale vertically
  (eg. the number threads given to each gridder instance).

Options:
  -ha, --host-address TEXT        Address where the distributed client lives.
                                  Will use a local cluster if no address is
                                  provided
  -nw, --nworkers INTEGER         Number of worker processes
  -ntpw, --nthreads-per-worker INTEGER
                                  Number of threads per worker process
  -nvthreads, --nvthreads INTEGER
                                  Number of threads used to scale vertically
                                  (eg. for FFTs)
  -nthreads, --nthreads INTEGER   Total number of threads to use between all
                                  processes. Will use all available resources
                                  by default
  -mem_limit, --mem-limit INTEGER
                                  Memory limit. Will use all available
                                  resources by default
  -scheduler, --scheduler TEXT    distributed | single-threaded/sync | threads
                                  [default: sync]
  -ms, --ms MS                    Path to measurement set.  [required]
  -o, --output-filename BASENAME  Basename of output  [required]
  --overwrite / --no-overwrite    Allow overwrite of output xds  [default: no-
                                  overwrite]
  -nb, --nband INTEGER            Number of imaging bands  [required]
  -dc, --data-column COLUMN       Data column to image. Must be the same
                                  across MSs  [default: DATA]
  -wc, --weight-column COLUMN     Column containing natural weights. Must be
                                  the same across MSs  [default:
                                  WEIGHT_SPECTRUM]
  -sc, --sigma-column COLUMN      Column containing standard devations. \ Will
                                  be used to initialise natural weights if
                                  detected. \ Must be the same across MSs
  -fc, --flag-column COLUMN       Column containing data flags. Must be the
                                  same across MSs  [default: FLAG]
  --gain-table TEXT               Path to Quartical gain table containing NET
                                  gains.There must be a table for each MS and
                                  glob(ms) and glob(gt) should match up.
  --gain-term TEXT                Which gain term to use. Default is NET
                                  [default: NET]
  -p, --product TEXT              Imaging products to produce. Options are I,
                                  Q, U, V. \ Only single Stokes products are
                                  currently supported  [default: I]
  -utpc, --utimes-per-chunk INTEGER
                                  Unique times per row chunk  [default: -1]
  --group-by-field / --no-group-by-field
                                  Split data by field  [default: group-by-
                                  field]
  --group-by-ddid / --no-group-by-ddid
                                  Split data by DDID  [default: group-by-ddid]
  --group-by-scan / --no-group-by-scan
                                  Split data by scan  [default: group-by-scan]
  --precision TEXT                "single" or "double"  [default: double]
  --bda-decorr FLOAT              BDA decorrelation factor. Only has an effect
                                  if less than one  [default: 1.0]
  --beam-model TEXT               Beam model to use
  -fov, --max-field-of-view DEG   Field of view in degrees  [default: 3.0]
  --help                          Show this message and exit.
```
so it looks like there is some issue with the python-ext runner. I can try to test this by running a python-ext cab through stimela without kubernetes I just don't know where I would find such a cab. @o-smirnov can you point me to an example?