### PR TITLE
Scatter, redone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ omegaconf = "^2.1"
 click = "^8.1.3"
 pyparsing = "^3.0.9"
 pydantic = "^1.10.2"
-pathos = "^0.3.0"
 psutil = "^5.9.3"
 rich = "^12.6.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pyparsing = "^3.0.9"
 pydantic = "^1.10.2"
 psutil = "^5.9.3"
 rich = "^12.6.0"
+dill = "^0.3.6"
 
 [tool.poetry.scripts]
 stimela = "stimela.main:cli"

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -6,7 +6,7 @@ import traceback
 from types import TracebackType
 from typing import Optional, OrderedDict, Union
 from omegaconf import DictConfig
-from scabha.exceptions import ScabhaBaseException
+from scabha.exceptions import ScabhaBaseException, FormattedTraceback
 from scabha.substitutions import SubstitutionNS, forgiving_substitutions_from
 import rich.progress
 import rich.logging
@@ -331,6 +331,10 @@ def log_exception(*errors, severity="error", log=None):
                 subtree = tree.add(f"[dim]Traceback:[/dim]")
                 for line in traceback.format_tb(exc):
                     subtree.add(f"[dim]{escape(line.rstrip())}[/dim]")
+            elif type(exc) is FormattedTraceback:
+                subtree = tree.add(f"[dim]Traceback:[/dim]")
+                for line in exc.lines:
+                    subtree.add(f"[dim]{escape(line)}[/dim]")
             elif isinstance(exc, (dict, OrderedDict, DictConfig)):
                 add_dict(exc, tree)
             else:

--- a/stimela/task_stats.py
+++ b/stimela/task_stats.py
@@ -123,6 +123,13 @@ def collect_stats():
     return _taskstats
 
 
+def add_missing_stats(stats):
+    """Adds stats that wren't recorded into dictionary"""
+    for key, value in stats.items():
+        if key not in _taskstats:
+            _taskstats[key] = value
+
+
 def stats_field_names():
     return _taskstats_sample_names
 

--- a/tests/stimela_tests/test_recipe.py
+++ b/tests/stimela_tests/test_recipe.py
@@ -84,3 +84,12 @@ def test_test_loop_recipe():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela exec test_loop_recipe.yml loop_recipe")
     assert retcode == 0
+
+def test_scatter():
+    print("===== expecting no errors now =====")
+    retcode = os.system("stimela exec test_scatter.yml basic_loop")
+    assert retcode == 0
+
+    print("===== expecting no errors now =====")
+    retcode = os.system("stimela exec test_scatter.yml nested_loop")
+    assert retcode == 0

--- a/tests/stimela_tests/test_scatter.yml
+++ b/tests/stimela_tests/test_scatter.yml
@@ -1,0 +1,77 @@
+
+## recipes may define or redefine or augment cabs
+cabs:
+  sleep:
+    command: sleep # just a dummy for now 
+    inputs:
+      seconds:
+        dtype: int
+        default: 1
+        policies:
+          positional: true
+  echo:
+    command: echo # just a dummy for now 
+    inputs:
+      arg:
+        dtype: str
+        required: true
+        policies:
+          positional: true
+
+## lib.recipes.* may be added to and invoked via _use
+lib:
+  recipes:
+    multi_echo:
+      info: 'runs multiple echo cabs'
+      inputs:
+        args:
+          dtype: List[str]
+          required: true
+      for_loop:
+        var: arg
+        over: args
+      assign:
+        log:
+          name: log-{recipe.arg}-{info.fqname}
+      steps: 
+        sleep:
+          cab: sleep
+        echo: 
+          cab: echo
+          params:
+            arg: =recipe.arg
+
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime} 
+    nest: 3
+    symlink: logs
+
+
+basic_loop:
+  _use: lib.recipes.multi_echo
+  defaults:
+    args: [1,2,3,4,5,6,7,8,9,10]
+  inputs:
+    for_loop:
+      scatter:
+        dtype: int
+        default: -1
+
+nested_loop:
+  for_loop:
+    var: subloop
+    over: subloops
+  inputs:
+    subloops:
+      dtype: List[str]
+      default: [a,b,c]
+    for_loop:
+      scatter:
+        dtype: int
+        default: -1
+  steps:
+    subloop-1: 
+      recipe: basic_loop
+    subloop-2:
+      recipe: basic_loop


### PR DESCRIPTION
@landmanbester you'll want to try this one too.

I've gone and fixed the scatter mechanism. Changed to using https://docs.python.org/3/library/concurrent.futures.html, as this allows nested process pools, and we can drop the pathos dependency.

I've also changed the definition of scatter to be an int, specifying the max number of workers. If scatter=-1, all for-loop iterations are scattered.

Finally, ``over`` and ``scatter`` will also be looked up within recipe inputs. So the following two are equivalent:

```yml
recipe_name:
  for_loop:
    var: x
    over: [1,2,3]
    scatter: -1
```

and

```yml
recipe_name:
  for_loop:
    var: x
  inputs:
    for_loop:
      over: 
        dtype: List[int]
        default: [1,2,3]
      scatter: 
        dtype: int
        default: -1
```
...but the latter construct allows the list of iterations (and the scatter parameter) to be passed to the recipe at run-time (i.e. from the command line, or from a previous step of a recipe, if the for-loop is in a sub-recipe). This should help things like https://github.com/caracal-pipeline/stimela2/issues/77
