### PR TITLE
Wrangler update, can parse outputs

### DIFF
--- a/stimela/backends/native/run_native.py
+++ b/stimela/backends/native/run_native.py
@@ -44,7 +44,7 @@ def run(cab: Cab, params: Dict[str, Any], runtime: Dict[str, Any], fqname: str,
     if cab.flavour == "python":
         return run_callable(cab.py_module, cab.py_function, cab, params, log, subst)
     elif cab.flavour == "python-code":
-        return _run_external_python(code, "python", cab, params, log, subst)
+        return _run_external_python(cab.command, "python", cab, params, log, subst)
     elif cab.flavour == "binary":
         return run_command(cab, params, log, subst)
     else:

--- a/stimela/exceptions.py
+++ b/stimela/exceptions.py
@@ -48,6 +48,9 @@ class StimelaRuntimeError(StimelaBaseException):
 class StimelaCabRuntimeError(StimelaBaseException):
     pass
 
+class StimelaCabOutputError(StimelaBaseException):
+    pass
+
 class StimelaProcessRuntimeError(StimelaBaseException):
     pass
 

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -3,13 +3,14 @@ from typing import Any, List, Dict, Optional, Union
 from collections import OrderedDict
 from enum import Enum, IntEnum
 from dataclasses import dataclass
-from omegaconf import MISSING
+from omegaconf import MISSING, OmegaConf
 
 from scabha.cargo import Parameter, Cargo, ListOrString, ParameterPolicies, ParameterCategory
-from stimela.exceptions import CabValidationError
+from stimela.exceptions import CabValidationError, StimelaCabRuntimeError
 from scabha.exceptions import SchemaError
 from scabha.basetypes import EmptyDictDefault, EmptyListDefault
 import stimela
+from . import wranglers
 
 ParameterPassingMechanism = Enum("ParameterPassingMechanism", "args yaml", module=__name__)
 
@@ -62,15 +63,6 @@ class Cab(Cargo):
     backend: Optional['stimela.config.Backend']
     runtime: Dict[str, Any] = EmptyDictDefault()
 
-    # copy names of logging levels into wrangler actions
-    wrangler_actions =  {attr: value for attr, value in logging.__dict__.items() if attr.upper() == attr and type(value) is int}
-
-    # then add litetal constants for other wrangler actions
-    ACTION_SUPPRESS = wrangler_actions["SUPPRESS"] = "SUPPRESS"
-    ACTION_DECLARE_SUCCESS = wrangler_actions["DECLARE_SUCCESS"] = "DECLARE_SUPPRESS"
-    ACTION_DECLARE_FAILURE = wrangler_actions["DECLARE_FAILURE"] = "DECLARE_FAILURE"
-
-
     _path: Optional[str] = None   # path to image definition yaml file, if any
 
     def __post_init__ (self):
@@ -92,34 +84,18 @@ class Cab(Cargo):
                 self.flavour = "binary" 
             else:
                 self.flavour = self.flavour.lower()
-            if self.flavour == "python" or self.flavour == "python-ext":
+            if self.flavour == "python":
                 if '.' in self.command:
                     self.py_module, self.py_function = self.command.rsplit('.', 1)
                 else:
                     raise CabValidationError("cab {self.name}: 'python' flavour requires a command of the form module.function")
-            elif self.flavour != "binary":
+            elif self.flavour not in ("binary", "python-code"):
                 raise CabValidationError("cab {self.name}: unknown cab flavour '{self.flavour}'")
 
         # setup wranglers
         self._wranglers = []
-        for match, actions in self.management.wranglers.items():
-            replace = None
-            if type(actions) is str:
-                actions = [actions]
-            if type(actions) is not list:
-                raise CabValidationError(f"wrangler entry {match}: expected action or list of actions")
-            for action in actions:
-                if action.startswith("replace:"):
-                    replace = action.split(":", 1)[1]
-                elif action not in self.wrangler_actions:
-                    raise CabValidationError(f"wrangler entry {match}: unknown action '{action}'")
-            actions = [self.wrangler_actions[act] for act in actions if act in self.wrangler_actions]
-            try:
-                rexp = re.compile(match)
-            except Exception as exc:
-                raise CabValidationError(f"wrangler entry {match} is not a valid regular expression")
-            self._wranglers.append((re.compile(match), replace, actions))
-        self._runtime_status = None
+        for pattern, actions in self.management.wranglers.items():
+            self._wranglers.append(wranglers.create_list(pattern, actions))
 
 
     def summary(self, params=None, recursive=True, ignore_missing=False):
@@ -340,34 +316,75 @@ class Cab(Cargo):
 
         return pos_args[0] + args + pos_args[1]
 
+    def reset_status(self):
+        return Cab.RuntimeStatus(self)
 
-    @property
-    def runtime_status(self):
-        return self._runtime_status
+    class RuntimeStatus(object):
+        """Represents the runtime status of a cab"""
 
-    def reset_runtime_status(self):
-        self._runtime_status = None
+        def __init__(self, cab: "Cab"):
+            self.cab = cab
+            self._success = None
+            self._errors = []
+            self._warnings = []
+            self._outputs = OrderedDict()
 
-    def apply_output_wranglers(self, output, severity):
-        suppress = False
-        modified_output = output
-        for regex, replace, actions in self._wranglers:
-            if regex.search(output):
-                if replace is not None:
-                    modified_output = regex.sub(replace, output)
-                for action in actions:
-                    if type(action) is int:
-                        severity = action
-                    elif action is self.ACTION_SUPPRESS:
-                        suppress = True
-                    elif action is self.ACTION_DECLARE_FAILURE and self._runtime_status is None:
-                        self._runtime_status  = False
-                        modified_output = "[FAILURE] " + modified_output
-                        severity = logging.ERROR
-                    elif action is self.ACTION_DECLARE_SUCCESS and self._runtime_status is None:
-                        self._runtime_status = True
-                        modified_output = "[SUCCESS] " + modified_output
-        return (None, 0) if suppress else (modified_output, severity)
+        @property
+        def success(self):
+            return self._success
 
+        @property
+        def errors(self):
+            return self._errors
 
+        @property
+        def warnings(self):
+            return self._warnings
 
+        @property
+        def outputs(self):
+            return self._outputs
+
+        def declare_success(self):
+            if self._success is None:
+                self._success = True
+
+        def declare_failure(self, error: Optional[Union[str, Exception]] = None):
+            self._success = False
+            if error is not None:
+                if type(error) is str:
+                    error = StimelaCabRuntimeError(error)
+                self._errors.append(error)
+
+        def declare_warning(self, message: str):
+            self._warnings.append(message)
+
+        def declare_outputs(self, outputs: Dict):
+            self._outputs.update(**outputs)
+
+        def apply_wranglers(self, output, severity):
+            suppress = False
+            for regex, wranglers in self.cab._wranglers:
+                match = regex.search(output) 
+                if match:
+                    for wrangler in wranglers:
+                        mod_output, mod_severity = wrangler.apply(self, output, match)
+                        # has wrangler asked to suppress the output?
+                        if mod_output is None:
+                            suppress = True
+                        else:
+                            output = mod_output
+                        # has wrangler modified the severity?
+                        if mod_severity is not None:
+                            severity = max(severity, mod_severity)
+
+            return (None, 0) if suppress else (output, severity)
+
+CabSchema = None
+
+def get_cab_schema():
+    global CabSchema
+    if CabSchema is None:
+        import stimela.config
+        CabSchema = OmegaConf.structured(Cab)
+    return CabSchema

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -1038,6 +1038,7 @@ class Recipe(Cargo):
                                 errors.append(tb)
                             nfail += 1
                     if errors:
+                        pool.shutdown()
                         raise StimelaRuntimeError(f"{nfail}/{len(loop_worker_args)} loop iterations failed", errors)
             # else just iterate directly
             else:

--- a/stimela/kitchen/runners.py
+++ b/stimela/kitchen/runners.py
@@ -3,12 +3,17 @@ from stimela import logger, config
 
 from .step import Step
 from .batch import Batch
+from .cab import Cab
 
-def run_cab(step: Step, params: Dict[str, Any], backend: 'config.Backend', subst: Optional[Dict[str, Any]] = None, batch: Batch=None):
+def run_cab(step: Step, params: Dict[str, Any], 
+            backend: 'config.Backend', 
+            subst: Optional[Dict[str, Any]] = None, 
+            batch: Batch=None) -> Cab.RuntimeStatus:
     log = step.log
     cab = step.cargo
     runtime = step.runtime
 
     backend = __import__(f"stimela.backends.{backend.name}", 
                          fromlist=[backend.name])
+    
     return backend.run(cab, runtime=runtime, params=params, log=log, subst=subst, batch=batch, fqname=step.fqname)

--- a/stimela/kitchen/wranglers.py
+++ b/stimela/kitchen/wranglers.py
@@ -3,7 +3,8 @@ from typing import Any, List, Dict, Optional, Union
 from omegaconf import ListConfig
 
 from scabha.cargo import ListOrString
-from stimela.exceptions import CabValidationError, StimelaCabOutputError, StimelaCabRuntimeError
+from stimela.exceptions import CabValidationError, StimelaCabOutputError, \
+                    StimelaCabRuntimeError
 
 # wranglers specified as a single string, or a list
 WranglerSpecList = ListOrString

--- a/stimela/kitchen/wranglers.py
+++ b/stimela/kitchen/wranglers.py
@@ -5,13 +5,27 @@ from omegaconf import ListConfig
 from scabha.cargo import ListOrString
 from stimela.exceptions import CabValidationError, StimelaCabOutputError, StimelaCabRuntimeError
 
-
+# wranglers specified as a single string, or a list
 WranglerSpecList = ListOrString
 
-# just for type hinting
+# defined just for type hinting below
 CabStatus = "stimela.kitchen.cab.Cab.RuntimeStatus"
 
+
 def create(regex: re.Pattern, spec: str):
+    """Creates wrangler object from a regex and a specification string, using the spec
+    string to look up a wrangler class below.
+
+    Args:
+        regex (re.Pattern): pattern in output which wrangler will match
+        spec (str): specification string
+
+    Raises:
+        CabValidationError: if the specification is incorrect
+
+    Returns:
+        wrangler: a wrangler object
+    """
     for specifier, wrangler_class in all_wranglers.items():
         match = re.fullmatch(specifier, spec)
         if match:
@@ -20,6 +34,18 @@ def create(regex: re.Pattern, spec: str):
 
 
 def create_list(pattern: Union[str, re.Pattern], spec_list: WranglerSpecList):
+    """Creates list of wranglers based on list of specifiers.
+
+    Args:
+        pattern (Union[str, re.Pattern]): pattern in output which wrangler will match
+        spec_list (WranglerSpecList): list of wrangler specs
+
+    Raises:
+        CabValidationError: if a specification is incorrect, or pattern is not a valid regex
+
+    Returns:
+        (re.Pattern, list): compiled regex pattern, plus list of wrangler objects
+    """
     if type(pattern) is str:
         try:
             regex = re.compile(pattern)
@@ -38,47 +64,91 @@ def create_list(pattern: Union[str, re.Pattern], spec_list: WranglerSpecList):
 
 
 class _BaseWrangler(object):
+    """Abstract base class for wrangler action classes.
+    
+    Each action class has a static 'specifier' attribute, which is a pattern used to match (and parse)
+    the specifier for that action. The pattern may contain named ()-groups (see e.g. Replace below),
+    note that the create() function above maps these to keyword arguments of the constructor.
+    """
+
     specifier = None
 
-    def __init__(self, regex: re.Pattern, action: str, **kw):
-        self.regex = regex
+    def __init__(self, regex: re.Pattern, spec: str, **kw):
+        """Action class constructor. Copies all keywords into object attributes.
+
+        Args:
+            regex (re.Pattern): pattern object which triggers this action
+            spec (str):         original action specifier string 
+            **kw (Any):         converted to object attributes
+        """
+        self.regex, self.spec = regex, spec
         for key, value in kw.items():
             setattr(self, key, value)
 
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
-        return output, None
+        """Abstract method. Applies the wrangler to a line of cab output.
+
+        Args:
+            cabstat (CabStatus): cab runtime status object, which may be updated based on output
+            output (str): line of output
+            match (re.Match): match object resulting from pattern matching
+        
+        Returns:
+            output (str or None), severity (int or None): [possibly] modified output string, or None to suppress
+                                                          modified log severity level, or None to not modify
+        """
+        raise RuntimeError("derived class does not implement an apply() method")
 
 class Replace(_BaseWrangler):
+    """
+    This wrangler will replace the matching pattern with the given string. Specified as REPLACE:replacement.
+    Uses re.sub() internally, so look that up for more complex usage.
+    """
     specifier = "REPLACE:(?P<replace>.*)"
     
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
         return self.regex.sub(self.replace, output), None
 
 class ChangeSeverity(_BaseWrangler):
-    specifier = "SEVERITY:(?P<severity>ERROR|WARNING|INFO)"
+    """
+    This wrangler will cause the output to be reported at the given severity level (instead of the
+    normal INFO level). Specified as SEVERITY:level, where level is one of the symbolic levels
+    defined in the standard logging module.
+    """
+    specifier = "SEVERITY:(?P<severity>ERROR|WARNING|INFO|DEBUG|CRITICAL|FATAL)"
     
-    def __init__(self, regex: re.Pattern, action: str, severity: str):
-        super().__init__(regex, action, severity=severity)
+    def __init__(self, regex: re.Pattern, spec: str, severity: str):
+        super().__init__(regex, spec, severity=severity)
         level = getattr(logging, severity, None)
         if level is None:
-            raise CabValidationError(f"wrangler action '{action}' for '{regex.pattern}': invalid logging level")
+            raise CabValidationError(f"wrangler action '{spec}' for '{regex.pattern}': invalid logging level")
         self.severity = level
 
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
         return output, self.severity
 
 class Suppress(_BaseWrangler):
+    """
+    This wrangler will cause the matching output to be suppressed. Specified as simply SUPPRESS.
+    """
     specifier = "SUPPRESS"
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
         return None, None
 
 class DeclareWarning(_BaseWrangler):
+    """
+    This wrangler will issue a warning once the cab completes. Specified as WARNING:message
+    """
     specifier = "WARNING:(?P<message>.*)"
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
         cabstat.declare_warning(self.message)
         return output, logging.WARNING
 
 class DeclareError(_BaseWrangler):
+    """
+    This wrangler will mark the cab as failed (even if the exit code is 0), and issue an optional error.
+    Specified as ERROR[:message]
+    """
     specifier = "ERROR(?::(?P<message>.*))?"
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
         err = StimelaCabRuntimeError(self.message or 
@@ -87,23 +157,35 @@ class DeclareError(_BaseWrangler):
         return f"[FAILURE] {output}", logging.ERROR
 
 class DeclareSuccess(_BaseWrangler):
+    """
+    This wrangler will mark the cab as succeeded (even if the exit code is non 0).
+    Specified as DECLARE_SUCCESS.
+    """
     specifier = "DECLARE_SUCCESS"
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
         cabstat.declare_success()
         return f"[SUCCESS] {output}", None
 
 class ParseOutput(_BaseWrangler):
-    loaders = dict(str=str, bool=bool, int=int, float=float, json=json.loads, JSON=json.loads)
+    """
+    This wrangler will parse a named output parameter out of the output. Specified as 
+    PARSE_OUTPUT:name:type. The matching pattern must have a ()-group with the same name,
+    or else the first ()-group will be parsed.
+    Type can be an atomic Python type (str, bool, int, float, complex), or 'json' to use
+    json.loads().
+    """
+
+    loaders = dict(str=str, bool=bool, int=int, float=float, complex=complex, json=json.loads, JSON=json.loads)
     specifier = f"PARSE_OUTPUT:(?P<name>.*):(?P<dtype>{'|'.join(loaders.keys())})"
 
-    def __init__(self, regex: re.Pattern, action: str, name: str, dtype: str):
-        super().__init__(regex, action, name=name)
+    def __init__(self, regex: re.Pattern, spec: str, name: str, dtype: str):
+        super().__init__(regex, spec, name=name)
         self.loader = self.loaders[dtype]
         if name in regex.groupindex:
             self.gid = name
         else:
             if regex.groups < 1:
-                raise CabValidationError(f"wrangler action '{action}' for '{regex.pattern}': no ()-groups")
+                raise CabValidationError(f"wrangler action '{spec}' for '{regex.pattern}': no ()-groups")
             self.gid = 1
 
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
@@ -116,13 +198,19 @@ class ParseOutput(_BaseWrangler):
         return output, None
 
 class ParseJSONOutput(_BaseWrangler):
+    """
+    This wrangler will parse multiple named output parameters (using JSON) out of the output. Specified as 
+    PARSE_JSON_OUTPUTS.
+    The pattern is expected to have one or more named ()-groups, which are matched to parameters.
+    """
+
     specifier = "PARSE_JSON_OUTPUTS"
 
-    def __init__(self, regex: re.Pattern, action: str):
-        super().__init__(regex, action)
+    def __init__(self, regex: re.Pattern, spec: str):
+        super().__init__(regex, spec)
         self.names = regex.groupindex.keys()
         if not self.names:
-            raise CabValidationError(f"wrangler action '{action}' for '{regex.pattern}': no ()-groups")
+            raise CabValidationError(f"wrangler action '{spec}' for '{regex.pattern}': no ()-groups")
 
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
         outputs = {}
@@ -137,12 +225,18 @@ class ParseJSONOutput(_BaseWrangler):
 
 
 class ParseJSONOutputDict(_BaseWrangler):
+    """
+    This wrangler will parse a dict of output parameters (using JSON) out of the output. Specified as 
+    PARSE_JSON_OUTPUT_DICT.
+    The first ()-group from the pattern will be parsed.
+    """
+
     specifier = "PARSE_JSON_OUTPUT_DICT"
 
-    def __init__(self, regex: re.Pattern, action: str):
-        super().__init__(regex, action)
+    def __init__(self, regex: re.Pattern, spec: str):
+        super().__init__(regex, spec)
         if regex.groups < 1:
-            raise CabValidationError(f"wrangler action '{action}' for '{regex.pattern}': no ()-groups")
+            raise CabValidationError(f"wrangler action '{spec}' for '{regex.pattern}': no ()-groups")
 
     def apply(self, cabstat: CabStatus, output: str, match: re.Match):
         try:

--- a/stimela/kitchen/wranglers.py
+++ b/stimela/kitchen/wranglers.py
@@ -1,0 +1,159 @@
+import re, logging, json
+from typing import Any, List, Dict, Optional, Union
+from omegaconf import ListConfig
+
+from scabha.cargo import ListOrString
+from stimela.exceptions import CabValidationError, StimelaCabOutputError, StimelaCabRuntimeError
+
+
+WranglerSpecList = ListOrString
+
+# just for type hinting
+CabStatus = "stimela.kitchen.cab.Cab.RuntimeStatus"
+
+def create(regex: re.Pattern, spec: str):
+    for specifier, wrangler_class in all_wranglers.items():
+        match = re.fullmatch(specifier, spec)
+        if match:
+            return wrangler_class(regex, spec, **match.groupdict())
+    raise CabValidationError(f"'{regex.pattern}': '{spec}' is not a valid wrangler specifier")
+
+
+def create_list(pattern: Union[str, re.Pattern], spec_list: WranglerSpecList):
+    if type(pattern) is str:
+        try:
+            regex = re.compile(pattern)
+        except Exception as exc:
+            raise CabValidationError(f"wrangler pattern '{pattern}' is not a valid regular expression", exc)
+    else:
+        regex = pattern
+        pattern = regex.pattern
+    
+    if type(spec_list) is str:
+        spec_list = [spec_list]
+    if not isinstance(spec_list, (list, tuple, ListConfig)):
+        raise CabValidationError(f"wrangler entry '{pattern}': expected list of wranglers")
+
+    return regex, [create(regex, spec) for spec in spec_list]
+
+
+class _BaseWrangler(object):
+    specifier = None
+
+    def __init__(self, regex: re.Pattern, action: str, **kw):
+        self.regex = regex
+        for key, value in kw.items():
+            setattr(self, key, value)
+
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        return output, None
+
+class Replace(_BaseWrangler):
+    specifier = "REPLACE:(?P<replace>.*)"
+    
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        return self.regex.sub(self.replace, output), None
+
+class ChangeSeverity(_BaseWrangler):
+    specifier = "SEVERITY:(?P<severity>ERROR|WARNING|INFO)"
+    
+    def __init__(self, regex: re.Pattern, action: str, severity: str):
+        super().__init__(regex, action, severity=severity)
+        level = getattr(logging, severity, None)
+        if level is None:
+            raise CabValidationError(f"wrangler action '{action}' for '{regex.pattern}': invalid logging level")
+        self.severity = level
+
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        return output, self.severity
+
+class Suppress(_BaseWrangler):
+    specifier = "SUPPRESS"
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        return None, None
+
+class DeclareWarning(_BaseWrangler):
+    specifier = "WARNING:(?P<message>.*)"
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        cabstat.declare_warning(self.message)
+        return output, logging.WARNING
+
+class DeclareError(_BaseWrangler):
+    specifier = "ERROR(?::(?P<message>.*))?"
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        err = StimelaCabRuntimeError(self.message or 
+            f"cab marked as failed based on encountering '{self.regex.pattern}' in output")
+        cabstat.declare_failure(err)
+        return f"[FAILURE] {output}", logging.ERROR
+
+class DeclareSuccess(_BaseWrangler):
+    specifier = "DECLARE_SUCCESS"
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        cabstat.declare_success()
+        return f"[SUCCESS] {output}", None
+
+class ParseOutput(_BaseWrangler):
+    loaders = dict(str=str, bool=bool, int=int, float=float, json=json.loads, JSON=json.loads)
+    specifier = f"PARSE_OUTPUT:(?P<name>.*):(?P<dtype>{'|'.join(loaders.keys())})"
+
+    def __init__(self, regex: re.Pattern, action: str, name: str, dtype: str):
+        super().__init__(regex, action, name=name)
+        self.loader = self.loaders[dtype]
+        if regex.groups < 1:
+            raise CabValidationError(f"wrangler action '{action}' for '{regex.pattern}': no ()-groups")
+
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        try:
+            value = self.loader(match.group(1))
+        except Exception as exc:
+            cabstat.declare_failure(StimelaCabOutputError(f"error parsing string \"{match.group(1)}\" for output '{name}'", exc))
+        cabstat.declare_outputs({self.name: value})
+        return output, None
+
+class ParseJSONOutput(_BaseWrangler):
+    specifier = "PARSE_JSON_OUTPUTS"
+
+    def __init__(self, regex: re.Pattern, action: str):
+        super().__init__(regex, action)
+        self.names = regex.groupindex.keys()
+        if not self.names:
+            raise CabValidationError(f"wrangler action '{action}' for '{regex.pattern}': no ()-groups")
+
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        outputs = {}
+        for name, value in match.groupdict().items():
+            if value is not None:
+                try:
+                    outputs[name] = json.loads(value)
+                except Exception as exc:
+                    cabstat.declare_failure(StimelaCabOutputError(f"error parsing string \"{value}\" for output '{name}'", exc))
+        cabstat.declare_outputs(outputs)
+        return output, None
+
+
+class ParseJSONOutputDict(_BaseWrangler):
+    specifier = "PARSE_JSON_OUTPUT_DICT"
+
+    def __init__(self, regex: re.Pattern, action: str):
+        super().__init__(self, regex, action)
+        if regex.groups < 1:
+            raise CabValidationError(f"wrangler action '{action}' for '{regex.pattern}': no ()-groups")
+
+    def apply(self, cabstat: CabStatus, output: str, match: re.Match):
+        try:
+            outputs = json.load(match.group(1))
+        except Exception as exc:
+            cabstat.declare_failure(StimelaCabOutputError(f"error parsing output dict from \"{self.name}'\"", exc))
+        cabstat.declare_outputs(outputs)
+        return output, None
+
+
+# build dictionary of all available wrangler action classes
+
+all_wranglers = {
+    cls.specifier: cls for _, cls in vars().items()
+        if isinstance(cls, type) and issubclass(cls, _BaseWrangler) and cls.specifier is not None
+}
+
+
+

--- a/stimela/schedulers/slurm.py
+++ b/stimela/schedulers/slurm.py
@@ -48,10 +48,10 @@ class SlurmBatch(Batch):
 
         # if retcode is not 0, and cab didn't declare itself a success,
         if retcode:
-            if not self.cab.runtime_status:
+            if not self.cab.runtime_success:
                 raise StimelaCabRuntimeError(f"{binary} returned non-zero exit status {retcode}", log=self.log)
         else:
-            if self.cab.runtime_status is False:
+            if self.cab.runtime_success is False:
                 raise StimelaCabRuntimeError(f"{binary} was marked as failed based on its output", log=self.log)
 
         return retcode

--- a/tests/stimela_tests/test_wranglers.py
+++ b/tests/stimela_tests/test_wranglers.py
@@ -64,3 +64,23 @@ def test_wrangler_force_failure():
     assert retcode != 0
     print(output)
     assert verify_output(output, "Nobody expected the fox!")
+
+def test_wrangler_parse():
+    print("===== expecting no errors =====")
+    retcode, output = run("stimela run test_wranglers.yml test_parse")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "The bloody cheetah ate 22 dogs!")
+
+    print("===== expecting no errors =====")
+    retcode, output = run("stimela run test_wranglers.yml test_parse2")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "The bloody cheetah ate 22 dogs!")
+
+    print("===== expecting no errors =====")
+    retcode, output = run("stimela run test_wranglers.yml test_parse3")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "The bloody cheetah ate 22 dogs!")
+

--- a/tests/stimela_tests/test_wranglers.py
+++ b/tests/stimela_tests/test_wranglers.py
@@ -1,0 +1,66 @@
+import os, re, subprocess, pytest
+
+
+# Change into directory where the test script lives
+# As suggested by https://stackoverflow.com/questions/62044541/change-pytest-working-directory-to-test-case-directory
+@pytest.fixture(autouse=True)
+def change_test_dir(request, monkeypatch):
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+def callable_function(a: int, b: str):
+    print(f"callable_function({a},'{b}')")
+
+
+def run(command):
+    """Runs command, returns tuple of exit code, output"""
+    print(f"running: {command}")
+    try:
+        return 0, subprocess.check_output(command, shell=True).strip().decode()
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode, exc.output.strip().decode()
+
+
+def verify_output(output, *regexes):
+    """Returns true if the output contains lines matching the regexes in sequence (possibly with other lines in between)"""
+    regexes = list(regexes[::-1])
+    for line in output.split("\n"):
+        if regexes and re.search(regexes[-1], line):
+            regexes.pop()
+    if regexes:
+        print("Error, the following regexes did not match the output:")
+        for regex in regexes:
+            print(f"  {regex}")
+        return False
+    return True
+
+
+def test_wrangler_replace_suppress():
+    print("===== expecting no errors =====")
+    retcode, output = run("stimela run test_wranglers.yml test_replace_suppress")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "Michael J. Fox", "don't need roads!")
+    assert not verify_output(output, "cheetah")
+
+
+def test_wrangler_force_success():
+    print("===== expecting no errors =====")
+    retcode, output = run("stimela run test_wranglers.yml test_force_success")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "deliberately declared")
+
+
+def test_wrangler_force_failure():
+    print("===== expecting an error =====")
+    retcode, output = run("stimela run test_wranglers.yml test_force_failure")
+    assert retcode != 0
+    print(output)
+    assert verify_output(output, "cab marked as failed")
+
+    print("===== expecting an error =====")
+    retcode, output = run("stimela run test_wranglers.yml test_force_failure2")
+    assert retcode != 0
+    print(output)
+    assert verify_output(output, "Nobody expected the fox!")

--- a/tests/stimela_tests/test_wranglers.txt
+++ b/tests/stimela_tests/test_wranglers.txt
@@ -1,0 +1,3 @@
+The quick brown fox jumps over the lazy dog
+The quick brown cheetah eats the 22 lazy dogs
+The lazy brown cow trips over the prone sloth

--- a/tests/stimela_tests/test_wranglers.txt
+++ b/tests/stimela_tests/test_wranglers.txt
@@ -1,3 +1,5 @@
 The quick brown fox jumps over the lazy dog
 The quick brown cheetah eats the 22 lazy dogs
 The lazy brown cow trips over the prone sloth
+The stubborn JSON loader reads {"eater": "cheetah", "num_dogs": 22}
+

--- a/tests/stimela_tests/test_wranglers.yml
+++ b/tests/stimela_tests/test_wranglers.yml
@@ -49,7 +49,9 @@ test_parse:
         command: cat test_wranglers.txt
         management:
           wranglers:
-            "brown (?P<eater>\\w+) eats the (?P<num_dogs>\\d+) lazy dogs": PARSE_JSON_OUTPUTS
+            "brown (?P<eater>\\w+) eats the (?P<num_dogs>\\d+) lazy dogs": 
+              - PARSE_OUTPUT:eater:str
+              - PARSE_OUTPUT:num_dogs:json
         outputs:
           eater:
             dtype: str
@@ -57,7 +59,63 @@ test_parse:
             dtype: int
     report:
       cab:
-        command: echo {current.who} ate {current.num} dogs!
+        command: echo The bloody {current.who} ate {current.num} dogs!
+        policies:
+          skip: true
+        inputs:
+          who:
+            dtype: str
+          num:
+            dtype: int
+      params:
+        who: =previous.eater
+        num: =previous.num_dogs
+
+test_parse2:
+  steps:
+    test_parse:
+      cab:
+        command: cat test_wranglers.txt
+        management:
+          wranglers:
+            "JSON loader reads ({.*})": PARSE_JSON_OUTPUT_DICT 
+        outputs:
+          eater:
+            dtype: str
+          num_dogs:
+            dtype: int
+    report:
+      cab:
+        command: echo The bloody {current.who} ate {current.num} dogs!
+        policies:
+          skip: true
+        inputs:
+          who:
+            dtype: str
+          num:
+            dtype: int
+      params:
+        who: =previous.eater
+        num: =previous.num_dogs
+
+test_parse3:
+  steps:
+    test_parse:
+      cab:
+        command: cat test_wranglers.txt
+        management:
+          wranglers:
+            "JSON loader reads {\"eater\": (?P<eater>.*), \"num_dogs\": (?P<num_dogs>.*)}": PARSE_JSON_OUTPUTS
+        outputs:
+          eater:
+            dtype: str
+          num_dogs:
+            dtype: int
+    report:
+      cab:
+        command: echo The bloody {current.who} ate {current.num} dogs!
+        policies:
+          skip: true
         inputs:
           who:
             dtype: str

--- a/tests/stimela_tests/test_wranglers.yml
+++ b/tests/stimela_tests/test_wranglers.yml
@@ -1,3 +1,9 @@
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime} 
+    nest: 3
+    symlink: logs
+
 
 test_replace_suppress:
   steps:

--- a/tests/stimela_tests/test_wranglers.yml
+++ b/tests/stimela_tests/test_wranglers.yml
@@ -1,0 +1,68 @@
+
+test_replace_suppress:
+  steps:
+    test_replace:
+      cab:
+        command: cat test_wranglers.txt
+        management:
+          wranglers:
+            "brown (fox|cow)": 
+              - REPLACE:Michael J. Fox
+              - SEVERITY:WARNING
+              - WARNING:Where we're going, we don't need roads!
+            "cheetah": SUPPRESS
+
+test_force_success:
+  steps:
+    test_success:
+      cab:
+        command: cat deliberately-missing-file
+        management:
+          wranglers:
+            "No such file": 
+              - DECLARE_SUCCESS
+              - WARNING:We have deliberately declared this cab a success.
+
+test_force_failure:
+  steps:
+    test_failure:
+      cab:
+        command: cat test_wranglers.txt
+        management:
+          wranglers:
+            fox: ERROR
+
+test_force_failure2:
+  steps:
+    test_failure:
+      cab:
+        command: cat test_wranglers.txt
+        management:
+          wranglers:
+            fox: 
+              - ERROR:Nobody expected the fox!
+
+test_parse:
+  steps:
+    test_parse:
+      cab:
+        command: cat test_wranglers.txt
+        management:
+          wranglers:
+            "brown (?P<eater>\\w+) eats the (?P<num_dogs>\\d+) lazy dogs": PARSE_JSON_OUTPUTS
+        outputs:
+          eater:
+            dtype: str
+          num_dogs:
+            dtype: int
+    report:
+      cab:
+        command: echo {current.who} ate {current.num} dogs!
+        inputs:
+          who:
+            dtype: str
+          num:
+            dtype: int
+      params:
+        who: =previous.eater
+        num: =previous.num_dogs


### PR DESCRIPTION
This implements #78, and opens the way to #82.

This also obviates ``crasa``, since everything can now be done with a few standard wrangler definitions within CASA cabs.