### PR TITLE
fixes #83. Silly CASA python2isms

### DIFF
--- a/stimela/backends/flavours/casa.py
+++ b/stimela/backends/flavours/casa.py
@@ -74,7 +74,7 @@ class CasaTaskFlavour(_CallableFlavour):
         pass_params = cab.filter_input_params(params)
         params_string = json.dumps(pass_params)
 
-        code = f"""import sys, json; {command}(**json.loads(sys.argv[-1]));"""
+        code = f"""import sys, json; kw=json.loads(sys.argv[-1]); kw={{key: (str(value) if type(value) is unicode else value) for key, value in kw.items()}}; {command}(**kw);"""
 
         args =  [casa] + casa_opts.strip().split() + ["-c", code, params_string]
         return args


### PR DESCRIPTION
Gah, CASA's ipython is still python2, and it doesn't like unicode strings coming from json.loads(). Added a workaround.