### PR TITLE
What If I want to use a commandline debugger for dev?

### DIFF
--- a/stimela/main.py
+++ b/stimela/main.py
@@ -53,10 +53,11 @@ class RunExecGroup(click.Group):
 @click.option('--clear-cache', '-C', is_flag=True, 
                 help="Reset the configuration cache. First thing to try in case of strange configuration errors.")
 @click.option('--verbose', '-v', is_flag=True, help='Be extra verbose in output.')
+@click.option('--dev', '-dev', is_flag=True, help='Dev mode, disables progress bar allowing cmd line debug.')
 @click.version_option(str(stimela.__version__))
-def cli(backend, config_files=[], config_dotlist=[], include=[], verbose=False, no_sys_config=False, clear_cache=False):
+def cli(backend, config_files=[], config_dotlist=[], include=[], verbose=False, no_sys_config=False, clear_cache=False, dev=False):
     global log
-    log = stimela.logger(loglevel=logging.DEBUG if verbose else logging.INFO)
+    log = stimela.logger(loglevel=logging.DEBUG if verbose else logging.INFO, dev=dev)
     log.info(f"starting")        # remove this eventually, but it's handy for timing things right now
 
     stimela.VERBOSE = verbose

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -136,7 +136,7 @@ def declare_chapter(title: str, **kw):
     progress_console.rule(title, **kw)
 
 
-def logger(name="STIMELA", propagate=False, boring=False, loglevel="INFO"):
+def logger(name="STIMELA", propagate=False, boring=False, loglevel="INFO", dev=False):
     """Returns the global Stimela logger (initializing if not already done so, with the given values)"""
     global _logger
     if _logger is None:
@@ -154,7 +154,7 @@ def logger(name="STIMELA", propagate=False, boring=False, loglevel="INFO"):
 
         log_formatter = log_boring_formatter if boring else log_colourful_formatter
 
-        progress_bar, progress_console = task_stats.init_progress_bar()
+        progress_bar, progress_console = task_stats.init_progress_bar(dev=dev)
 
         log_console_handler = rich.logging.RichHandler(console=progress_console,
                             highlighter=rich.highlighter.NullHighlighter(), markup=True,

--- a/stimela/task_stats.py
+++ b/stimela/task_stats.py
@@ -22,7 +22,7 @@ _start_time = datetime.now()
 _prev_disk_io = None, None
 
 
-def init_progress_bar():
+def init_progress_bar(dev=False):
     global progress_console, progress_bar, progress_task
     progress_console = rich.console.Console(file=sys.stdout, highlight=False)
     progress_bar = rich.progress.Progress(
@@ -35,7 +35,8 @@ def init_progress_bar():
         "{task.fields[cpu_info]}",
         refresh_per_second=2,
         console=progress_console,
-        transient=True)
+        transient=True,
+        disable=dev)
 
     progress_task = progress_bar.add_task("stimela", command="starting", cpu_info=" ", elapsed_time="", start=True)
     progress_bar.__enter__()


### PR DESCRIPTION
- Adds dev option to switch animated progress bar off. To be accessed by:
`stimela --dev run blabla`
not sure if this is the way to do it, but works well for me
- Small fixe for some string parsing in casa flavour backend
- Small error message fix