### PR TITLE
Adds slurm support

### DIFF
--- a/stimela/backends/__init__.py
+++ b/stimela/backends/__init__.py
@@ -10,6 +10,7 @@ from scabha.basetypes import EmptyDictDefault
 from .singularity import SingularityBackendOptions
 from .kube import KubeBackendOptions
 from .native import NativeBackendOptions
+from .slurm import SlurmOptions
 
 import stimela
 
@@ -20,11 +21,15 @@ Backend = Enum("Backend", "singularity kube native", module=__name__)
 SUPPORTED_BACKENDS = set(Backend.__members__)
 
 
-def get_backend(name: str):
+def get_backend(name: str, backend_opts: Optional[Dict] = None):
+    """
+    Gets backend, given a name and an optional set of options for that backend.
+    Returns backend module, or None if it is not available.
+    """
     if name not in SUPPORTED_BACKENDS:
         return None
     backend = __import__(f"stimela.backends.{name}", fromlist=[name])
-    if backend.is_available():
+    if backend.is_available(backend_opts):
         return backend
     return None
 
@@ -48,7 +53,7 @@ class StimelaBackendOptions(object):
     kube: Optional[KubeBackendOptions] = None
     native: Optional[NativeBackendOptions] = None 
     docker: Optional[Dict] = None  # placeholder for future impl
-    slurm: Optional[Dict] = None   # placeholder for future impl
+    slurm: Optional[SlurmOptions] = None   
 
     ## Resource limits applied during run -- see resource module
     rlimits: Dict[str, Any] = EmptyDictDefault()
@@ -71,6 +76,8 @@ class StimelaBackendOptions(object):
             self.native = NativeBackendOptions()
         if self.kube is None and get_backend("kube"):
             self.kube = KubeBackendOptions()
+        if self.kube is None and get_backend("slurm"):
+            self.kube = SlurmBackendOptions()
 
 StimelaBackendSchema = OmegaConf.structured(StimelaBackendOptions)
 
@@ -106,7 +113,7 @@ def _call_backends(backend_opts: StimelaBackendOptions, log: logging.Logger, met
         # check that backend has not been disabled
         opts = getattr(backend_opts, engine, None)
         if not opts or opts.enable:
-            backend = get_backend(engine)
+            backend = get_backend(engine, opts)
             func = backend and getattr(backend, method, None)
             if func:
                 try:

--- a/stimela/backends/__init__.py
+++ b/stimela/backends/__init__.py
@@ -76,8 +76,8 @@ class StimelaBackendOptions(object):
             self.native = NativeBackendOptions()
         if self.kube is None and get_backend("kube"):
             self.kube = KubeBackendOptions()
-        if self.kube is None and get_backend("slurm"):
-            self.kube = SlurmBackendOptions()
+        if self.slurm is None:
+            self.slurm = SlurmOptions()
 
 StimelaBackendSchema = OmegaConf.structured(StimelaBackendOptions)
 

--- a/stimela/backends/docker.py
+++ b/stimela/backends/docker.py
@@ -25,7 +25,7 @@ from stimela import log_exception
 
 STATUS = VERSION = BINARY = None
 
-def is_available():
+def is_available(opts = None):
     global STATUS, VERSION, BINARY
     if STATUS is None:
         BINARY = which("docker")

--- a/stimela/backends/kube/__init__.py
+++ b/stimela/backends/kube/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 from omegaconf import OmegaConf
 from dataclasses import dataclass
@@ -247,7 +247,11 @@ def cleanup(backend: 'stimela.backend.StimelaBackendOptions', log: logging.Logge
 
 def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
         backend: 'stimela.backend.StimelaBackendOptions',
-        log: logging.Logger, subst: Optional[Dict[str, Any]] = None):
+        log: logging.Logger, subst: Optional[Dict[str, Any]] = None,
+        command_wrapper: Optional[Callable] = None):
+    # normally runner.py won't allow this, but check just in case
+    if command_wrapper:
+        raise BackendError(f"kube backend cannot be used with a command wrapper")
     from . import run_kube
     return run_kube.run(cab=cab, params=params, fqname=fqname, backend=backend, log=log, subst=subst)
 

--- a/stimela/backends/kube/run_kube.py
+++ b/stimela/backends/kube/run_kube.py
@@ -31,8 +31,7 @@ from stimela.backends.utils import resolve_remote_mounts
 
 def run(cab: Cab, params: Dict[str, Any], fqname: str,
         backend: StimelaBackendOptions,
-        log: logging.Logger, subst: Optional[Dict[str, Any]] = None,
-        command_wrapper: Optional[Callable] = None):
+        log: logging.Logger, subst: Optional[Dict[str, Any]] = None):
     """Runs cab contents
 
     Args:
@@ -43,10 +42,6 @@ def run(cab: Cab, params: Dict[str, Any], fqname: str,
     Returns:
         Any: return value (e.g. exit code) of content
     """
-
-    # normally runner.py won't allow this, but check just in case
-    if command_wrapper:
-        raise BackendError(f"kube backend cannot be used with a command wrapper")
 
     if not cab.image:
         raise BackendError(f"kube backend requires cab.image to be set")

--- a/stimela/backends/kube/run_kube.py
+++ b/stimela/backends/kube/run_kube.py
@@ -1,5 +1,5 @@
 import logging, time, json, datetime, os.path, pathlib, secrets, shlex
-from typing import Dict, Optional, Any, List
+from typing import Dict, Optional, Any, List, Callable
 from dataclasses import fields
 from datetime import timedelta
 from requests import ConnectionError
@@ -31,7 +31,8 @@ from stimela.backends.utils import resolve_remote_mounts
 
 def run(cab: Cab, params: Dict[str, Any], fqname: str,
         backend: StimelaBackendOptions,
-        log: logging.Logger, subst: Optional[Dict[str, Any]] = None):
+        log: logging.Logger, subst: Optional[Dict[str, Any]] = None,
+        command_wrapper: Optional[Callable] = None):
     """Runs cab contents
 
     Args:
@@ -43,14 +44,18 @@ def run(cab: Cab, params: Dict[str, Any], fqname: str,
         Any: return value (e.g. exit code) of content
     """
 
+    # normally runner.py won't allow this, but check just in case
+    if command_wrapper:
+        raise BackendError(f"kube backend cannot be used with a command wrapper")
+
     if not cab.image:
-        raise StimelaCabRuntimeError(f"kube runner requires cab.image to be set")
+        raise BackendError(f"kube backend requires cab.image to be set")
 
     kube = backend.kube
 
     namespace = kube.namespace
     if not namespace:
-        raise StimelaCabRuntimeError(f"runtime.kube.namespace must be set")
+        raise BackendError(f"runtime.kube.namespace must be set")
 
     args = cab.flavour.get_arguments(cab, params, subst, check_executable=False)
     log.debug(f"command line is {args}")

--- a/stimela/backends/native/__init__.py
+++ b/stimela/backends/native/__init__.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 import stimela
 
-def is_available():
+def is_available(opts = None):
     return True
 
 def get_status():

--- a/stimela/backends/native/run_native.py
+++ b/stimela/backends/native/run_native.py
@@ -1,6 +1,6 @@
 import logging, datetime, resource, os.path
 
-from typing import Dict, Optional, Any, List
+from typing import Dict, Optional, Any, List, Callable
 
 import stimela
 import stimela.kitchen
@@ -37,14 +37,18 @@ def build_command_line(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], s
 
 def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
         backend: 'stimela.backend.StimelaBackendOptions',
-        log: logging.Logger, subst: Optional[Dict[str, Any]] = None):
-    """Runs cab contents
+        log: logging.Logger, subst: Optional[Dict[str, Any]] = None,
+        command_wrapper: Optional[Callable] = None):
+    """
+    Runs cab contents
 
     Args:
-        cab (Cab): cab object
+        cab: cab object
+        params: cab parameters
+        backend: backed settings object
         log (logger): logger to use
         subst (Optional[Dict[str, Any]]): Substitution dict for commands etc., if any.
-
+        command_wrapper (Callable): takes a list of args and returns modified list of args
     Returns:
         Any: return value (e.g. exit code) of content
     """
@@ -79,6 +83,9 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
         return str(datetime.datetime.now() - (since or start_time)).split('.', 1)[0]
 
     # log.info(f"argument lengths are {[len(a) for a in args]}")
+    
+    if command_wrapper:
+        args = command_wrapper(args)
 
     retcode = xrun(args[0], args[1:], shell=False, log=log,
                 output_wrangler=cabstat.apply_wranglers,

--- a/stimela/backends/podman.py
+++ b/stimela/backends/podman.py
@@ -8,7 +8,7 @@ import time
 import datetime
 import tempfile
 
-def is_available():
+def is_available(opts = None):
     return False
 
 def get_status():

--- a/stimela/backends/runner.py
+++ b/stimela/backends/runner.py
@@ -1,12 +1,31 @@
+import logging
 from typing import Dict, Optional, Any
+from dataclasses import dataclass
 from omegaconf import OmegaConf
 from omegaconf.errors import OmegaConfBaseException 
+import stimela
 from stimela.backends import StimelaBackendOptions, StimelaBackendSchema
 from stimela.exceptions import BackendError
 
-from . import get_backend, get_backend_status
+from . import get_backend, get_backend_status, slurm
 
-def validate_backend_settings(backend_opts: Dict[str, Any]):
+
+@dataclass
+class BackendWrapper(object):
+    opts: StimelaBackendOptions
+    is_remote: bool
+    is_remote_fs: bool
+    main_backend: None
+    command_wrapper: None
+
+    def run(self, cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
+            log: logging.Logger, subst: Optional[Dict[str, Any]] = None):
+        self.main_backend.run(cab, params, fqname=fqname, backend=self.opts, log=log, subst=subst, 
+                              command_wrapper=self.command_wrapper)
+       
+
+
+def validate_backend_settings(backend_opts: Dict[str, Any]) -> BackendWrapper:
     """Checks that backend settings refer to a valid backend
     
     Returs tuple of options, main, wrapper, where 'main' the the main backend, and 'wrapper' is an optional wrapper backend 
@@ -22,19 +41,25 @@ def validate_backend_settings(backend_opts: Dict[str, Any]):
         # check that backend has not been disabled
         opts = getattr(backend_opts, engine, None)
         if not opts or opts.enable:
-            main_backend = get_backend(engine)
+            main_backend = get_backend(engine, opts)
             if main_backend is not None:
                 main = engine
                 break
     else:
         raise BackendError(f"selected backends ({', '.join(selected)}) not available")
-    
-    # check if slurm wrapper is to be applied
-    wrapper = None
-    if False:   # placeholder -- should be: if backend.slurm and backed.slurm.enable
-        wrapper = get_backend('slurm') 
-        if wrapper is None:
-            raise BackendError(f"backend 'slurm' not available ({get_backend_status('slurm')})")
 
-    return backend_opts, main_backend, wrapper
+    is_remote = is_remote_fs = main_backend.is_remote()
+
+    # check if slurm wrapper is to be applied
+    if backend_opts.slurm.enabled:
+        if is_remote:
+            raise BackendError(f"can't combine slurm with {main} backend")
+        is_remote = True
+        is_remote_fs = False
+        command_wrapper = backend_opts.slurm.command_wrapper
+    else:
+        command_wrapper = None
+
+    return BackendWrapper(opts=backend_opts, is_remote=is_remote, is_remote_fs=is_remote_fs, 
+                          main_backend=main_backend, command_wrapper=command_wrapper)
 

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -240,6 +240,9 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
 
     # log.info(f"argument lengths are {[len(a) for a in args]}")
 
+    if command_wrapper:
+        args = command_wrapper(args)
+
     retcode = xrun(args[0], args[1:], shell=False, log=log,
                 output_wrangler=cabstat.apply_wranglers,
                 return_errcode=True, command_name=command_name, 

--- a/stimela/backends/slurm.py
+++ b/stimela/backends/slurm.py
@@ -16,7 +16,6 @@ from stimela.utils.xrun_asyncio import xrun
 from stimela.exceptions import BackendError
 
 
-
 # path to default srun binary
 _default_srun_path = None
 

--- a/stimela/backends/slurm.py
+++ b/stimela/backends/slurm.py
@@ -19,13 +19,12 @@ from stimela.exceptions import BackendError
 # path to default srun binary
 _default_srun_path = None
 
-
 @dataclass
 class SlurmOptions(object):
-    enable: bool = True
-    srun_path: Optional[str] = None              # path to executable
-    srun_opts: Dict[str, str] = EmptyDictDefault()
-    build_local = True
+    enable: bool = False                            # enables passing off jobs to slurm via srun
+    srun_path: Optional[str] = None                 # path to srun executable
+    srun_opts: Dict[str, str] = EmptyDictDefault()  # extra options passed to srun. "--" prepended, and "_" replaced by "-"
+    build_local = True                              # if True, images will be built locally (i.e. on the head node) even when slurm is enabled
 
     def get_executable(self):
         global _default_srun_path
@@ -59,7 +58,6 @@ class SlurmOptions(object):
         if self.build_local:
             return args
         return self.run_command_wrapper(args, fqname=fqname)
-
 
 
 SlurmOptionsSchema = OmegaConf.structured(SlurmOptions)

--- a/stimela/backends/slurm.py
+++ b/stimela/backends/slurm.py
@@ -1,0 +1,77 @@
+import subprocess
+import os
+import re
+import logging
+from stimela import utils
+import stimela
+from shutil import which
+from dataclasses import dataclass, make_dataclass
+from omegaconf import OmegaConf
+from typing import Dict, List, Any, Optional, Tuple
+from contextlib import ExitStack
+from scabha.basetypes import EmptyListDefault
+import datetime
+from stimela.utils.xrun_asyncio import xrun
+
+from stimela.exceptions import BackendError
+
+
+
+# path to default srun binary
+_default_srun_path = None
+
+# map from SlurmOptions attributes to srun options
+
+# Dictionary of supported srun options -- these directly map to fields of the SlurmOptions dataclass
+# Just keep on adding them here as needed
+_srun_options = dict(
+    account=str,
+    chdir=str,
+    clusters=str,
+    constraint=str,
+    mem=str,
+    mem_per_cpu=str,
+    mincpus=int,
+    partition=int
+)
+
+# create the basic options dataclass
+_BaseSlurmOptions = make_dataclass("BaseSlurmOptions", 
+                    [(name, Optional[dtype], None) for name, dtype in _srun_options.items()]
+)
+
+@dataclass
+class SlurmOptions(_BaseSlurmOptions):
+    enable: bool = True
+    srun: Optional[str] = None              # path to executable
+
+    def get_executable(self):
+        global _default_srun_path
+        if self.srun is None:
+            if _default_srun_path is None:
+                _default_srun_path = which("srun")
+                if not _default_srun_path:
+                    _default_srun_path = False
+            if _default_srun_path is False:
+                raise BackendError(f"slurm 'srun' binary not found")
+            return _default_srun_path
+        else:
+            if not os.access(self.srun, os.X_OK):
+                raise BackendError(f"slurm.srun path '{self.srun}' is not an executable")
+            return self.srun
+        
+    def command_wrapper(self, args: List[str]):
+        output_args = [self.get_executable()]
+
+        # add all base options that have been specified
+        for name in _srun_options.keys():
+            value = getattr(self, name)
+            if value is not None:
+                output_args += ["--" + name.replace("_", "-"), value]
+
+        output_args += args
+        return args
+
+
+SlurmOptionsSchema = OmegaConf.structured(SlurmOptions)
+

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -330,12 +330,10 @@ class Step:
             backend = OmegaConf.merge(backend, self.cargo.backend or {}, self.backend or {})
             backend_opts = evaluate_and_substitute_object(backend, subst, recursion_level=-1, location=[self.fqname, "backend"])
             backend_opts = OmegaConf.to_object(OmegaConf.merge(StimelaBackendSchema, backend_opts))
-            backend_opts, backend_main, backend_wrapper =  runner.validate_backend_settings(backend_opts)
+            backend_wrapper = runner.validate_backend_settings(backend_opts)
         except Exception as exc:
             newexc = BackendError("error validating backend settings", exc)
             raise newexc from None
-            # self.log_exception(newexc)
-        remote_backend = backend_main.is_remote()
 
         # if step is being explicitly skipped, omit from profiling, and drop info/warning messages to debug level
         explicit_skip = self.skip is True 
@@ -343,7 +341,7 @@ class Step:
             context = nullcontext()
             parent_log_info = parent_log_warning = parent_log.debug
         else:
-            context = stimelogging.declare_subtask(self.name, hide_local_metrics=remote_backend)
+            context = stimelogging.declare_subtask(self.name, hide_local_metrics=backend_wrapper.is_remote)
             stimelogging.declare_chapter(f"{self.fqname}")
             parent_log_info, parent_log_warning = parent_log.info, parent_log.warning
 
@@ -373,7 +371,7 @@ class Step:
             self.log.debug(f"validating inputs {subst and list(subst.keys())}")
             validated = None
             try:
-                params = self.cargo.validate_inputs(params, loosely=skip, remote_fs=remote_backend, subst=subst)
+                params = self.cargo.validate_inputs(params, loosely=skip, remote_fs=backend_wrapper.is_remote_fs, subst=subst)
                 validated = True
 
             except ScabhaBaseException as exc:
@@ -425,7 +423,7 @@ class Step:
 
             ## check if we need to skip based on existing/fresh file outputs
             ## if skip on fresh outputs is in effect, find mtime of most recent input 
-            if not remote_backend and not skip and self.skip_if_outputs:
+            if not backend_wrapper.is_remote_fs and not skip and self.skip_if_outputs:
                 # max_mtime will remain 0 if we're not echecking for freshness, or if there are no file-type inputs
                 max_mtime, max_mtime_path = 0, None
                 if self.skip_if_outputs == OUTPUTS_FRESH:
@@ -515,7 +513,7 @@ class Step:
 
             if not skip:
                 # check for outputs that need removal
-                if not remote_backend:
+                if not backend_wrapper.is_remote_fs:
                     for name, schema in self.outputs.items():
                         if name in params and schema.remove_if_exists and schema.is_file_type:
                             path = params[name]
@@ -528,7 +526,7 @@ class Step:
                 if type(self.cargo) is Recipe:
                     self.cargo._run(params, subst, backend=backend)
                 elif type(self.cargo) is Cab:
-                    cabstat = backend_main.run(self.cargo, params=params, log=self.log, subst=subst, backend=backend_opts, fqname=self.fqname)
+                    cabstat = backend_wrapper.run(self.cargo, params=params, log=self.log, subst=subst, fqname=self.fqname)
                     # check for runstate
                     if cabstat.success is False:
                         raise StimelaCabRuntimeError(f"error running cab '{self.cargo.name}'", cabstat.errors)
@@ -547,7 +545,7 @@ class Step:
             validated = False
 
             try:
-                params = self.cargo.validate_outputs(params, loosely=skip,remote_fs=remote_backend, subst=subst)
+                params = self.cargo.validate_outputs(params, loosely=skip,remote_fs=backend_wrapper.is_remote_fs, subst=subst)
                 validated = True
             except ScabhaBaseException as exc:
                 severity = "warning" if skip else "error"

--- a/stimela/main.py
+++ b/stimela/main.py
@@ -89,9 +89,9 @@ def cli(config_files=[], config_dotlist=[], include=[], backend=None,
     if config.CONFIG_LOADED:
         log.info(f"loaded config from {config.CONFIG_LOADED}") 
 
-    # select backend
+    # select backend, passing it any config options that have been set up
     if backend:
-        if backends.get_backend(backend) is None:
+        if backends.get_backend(backend, getattr(stimela.CONFIG.opts.backend, backend, None)) is None:
             log.error(f"backend '{backend}' not available: {backends.get_backend_status(backend)}")
             sys.exit(1)
 

--- a/stimela/main.py
+++ b/stimela/main.py
@@ -118,7 +118,7 @@ def cli(config_files=[], config_dotlist=[], include=[], backend=None,
 
 
 # import commands
-from stimela.commands import doc, run, save_config, cleanup
+from stimela.commands import doc, run, build, save_config, cleanup
 
 ## These one needs to be reimplemented, current backed auto-pulls and auto-builds:
 # images, pull, build, clean

--- a/tests/stimela_tests/test_slurm.yml
+++ b/tests/stimela_tests/test_slurm.yml
@@ -1,0 +1,34 @@
+_include:
+  - (cultcargo)breizorro.yml
+  # note that this looks in . first, then at the location of testy_kube.yml, if different
+  - test_slurm_config.yml
+
+opts:
+  backend:
+    select: singularity
+    singularity:
+      auto_build: false    # on slurm, we pre-build on the head node explitictly
+    slurm:
+      enable: true
+
+recipe:
+  name: "demo recipe"
+  info: 'top level recipe definition'
+  for_loop:
+    var: threshold
+    over: [5,6,7,8,9]
+    scatter: -1
+  steps:
+      mask1:
+        cab: breizorro
+        params:
+          restored-image: im3-MFS-image.fits
+          threshold: =recipe.threshold
+          mask: =STRIPEXT(current.restored-image) + "th{recipe.threshold}.mask.fits"
+      mask2:
+        recipe:
+        cab: breizorro
+        params:
+          mask-image: =previous.mask
+          dilate: 2
+          mask: =STRIPEXT(previous.restored-image) + "th{recipe.threshold}.mask2.fits"


### PR DESCRIPTION
@SpheMakh, in the interest of smaller PRs, review early, review often please!

@Athanaseus this ought to get you going. The slurm backend "wrapper" is enabled like so: https://github.com/caracal-pipeline/stimela/blob/e61296dc76d5d61281be8b4c966b26ec274f932c/tests/stimela_tests/test_slurm.yml#L11

This causes all commands to be wrapped in an ``srun`` call. Just add ``scatter: -1`` to your for-loops, and you're all parallel. 

(I call it a  "wrapper" because it wraps an actual backend like "native" or "singularity" -- it is not a backend on its own per se.)

The recipe itself is meant to be run on the head node (inside a tmux or screen session, of course).

Under slurm, you don't want to be building Singularity images on-demand on the compute nodes. Rather, pre-build all necessary images on the head node before you run a recipe. There is a new ``stimela build recipe.yml`` command that will do this (options very similar to the run command). You should also disable on-demand building of images during the run like so: https://github.com/caracal-pipeline/stimela/blob/e61296dc76d5d61281be8b4c966b26ec274f932c/tests/stimela_tests/test_slurm.yml#L10

You'll probably want to tweak srun options on a per-cab (or per-step) basis. This is done similarly to how we tweak k8s settings per cab here: https://github.com/caracal-pipeline/stimela/blob/e61296dc76d5d61281be8b4c966b26ec274f932c/tests/stimela_tests/test_kube_config.yml#L42

So, something like:

```yml
cabs:
  breizorro:
    backend:
      slurm:
        srun_opts:
          mem: 16GB
          cpus_per_task: 4 
```

..will run breizorro with ``srun --mem 16GB --cpus-per-task 4``. The ``srun_opts`` section is free-form, so 
[all srun options](https://slurm.schedmd.com/srun.html) are supported.

