### PR TITLE
Issue 189

### DIFF
--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -127,6 +127,11 @@ class Parameter(object):
     # if true, treat parameter as a path, and ensure that the parent directories it refers to exist
     mkdir: bool = False
 
+    # if True, and parameter is a path, access to its parent directory is required
+    access_parent_dir: bool = False
+    # if True, and parameter is a path, access to its parent directory is required in writable mode
+    write_parent_dir: bool = False
+
     # for file and dir-type parameters: if True, the file(s)/dir(s) must exist. If False, they can be missing.
     # if None, then the default logic applies: inputs must exist, and outputs don't
     must_exist: Optional[bool] = None

--- a/stimela/backends/runner.py
+++ b/stimela/backends/runner.py
@@ -32,7 +32,7 @@ class BackendWrapper(object):
                                 command_wrapper=self.build_command_wrapper)
 
 
-def validate_backend_settings(backend_opts: Dict[str, Any]) -> BackendWrapper:
+def validate_backend_settings(backend_opts: Dict[str, Any], log: logging.Logger) -> BackendWrapper:
     """Checks that backend settings refer to a valid backend
     
     Returs tuple of options, main, wrapper, where 'main' the the main backend, and 'wrapper' is an optional wrapper backend 
@@ -63,6 +63,7 @@ def validate_backend_settings(backend_opts: Dict[str, Any]) -> BackendWrapper:
             raise BackendError(f"can't combine slurm with {backend_name} backend")
         is_remote = True
         is_remote_fs = False
+        backend_opts.slurm.validate(log)
         run_command_wrapper = backend_opts.slurm.run_command_wrapper
         build_command_wrapper = backend_opts.slurm.build_command_wrapper
     else:

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -199,7 +199,7 @@ def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBacke
         args = [BINARY, "build", simg_path, f"docker://{image_name}"]
 
         if command_wrapper:
-            args = command_wrapper(args)
+            args = command_wrapper(args, log=log)
 
         retcode = xrun(args[0], args[1:], shell=False, log=log,
                     return_errcode=True, command_name="(singularity build)", 
@@ -272,7 +272,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
     # log.info(f"argument lengths are {[len(a) for a in args]}")
 
     if command_wrapper:
-        args = command_wrapper(args, fqname=fqname)
+        args = command_wrapper(args, fqname=fqname, log=log)
 
     retcode = xrun(args[0], args[1:], shell=False, log=log,
                 output_wrangler=cabstat.apply_wranglers,

--- a/stimela/backends/slurm.py
+++ b/stimela/backends/slurm.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, make_dataclass
 from omegaconf import OmegaConf
 from typing import Dict, List, Any, Optional, Tuple
 from contextlib import ExitStack
-from scabha.basetypes import EmptyListDefault, EmptyDictDefault
+from scabha.basetypes import EmptyListDefault, EmptyDictDefault, ListDefault
 import datetime
 from stimela.utils.xrun_asyncio import xrun
 
@@ -25,6 +25,8 @@ class SlurmOptions(object):
     srun_path: Optional[str] = None                 # path to srun executable
     srun_opts: Dict[str, str] = EmptyDictDefault()  # extra options passed to srun. "--" prepended, and "_" replaced by "-"
     build_local = True                              # if True, images will be built locally (i.e. on the head node) even when slurm is enabled
+    # these will be checked for
+    required_mem_opts: Optional[List[str]] = ListDefault("mem", "mem-per-cpu", "mem-per-gpu")
 
     def get_executable(self):
         global _default_srun_path
@@ -41,7 +43,7 @@ class SlurmOptions(object):
                 raise BackendError(f"slurm.srun_path '{self.srun}' is not an executable")
             return self.srun
         
-    def run_command_wrapper(self, args: List[str], fqname: Optional[str]=None) -> List[str]:
+    def run_command_wrapper(self, args: List[str], fqname: Optional[str]=None, log: Optional[logging.Logger]=None) -> List[str]:
         output_args = [self.get_executable()]
 
         if fqname is not None:
@@ -49,15 +51,22 @@ class SlurmOptions(object):
 
         # add all base options that have been specified
         for name, value in self.srun_opts.items():
-            output_args += ["--" + name.replace("_", "-"), value]
+            output_args += ["--" + name, value]
 
         output_args += args
         return output_args
     
-    def build_command_wrapper(self, args: List[str], fqname: Optional[str]=None) -> List[str]:
+    def build_command_wrapper(self, args: List[str], fqname: Optional[str]=None, log: Optional[logging.Logger]=None) -> List[str]:
         if self.build_local:
             return args
-        return self.run_command_wrapper(args, fqname=fqname)
+        return self.run_command_wrapper(args, fqname=fqname, log=log)
+    
+    def validate(self, log: logging.Logger):
+        if self.required_mem_opts:
+            if not set(self.srun_opts.keys()).intersection(self.required_mem_opts):
+                raise BackendError(f"slurm.srun_opts must set one of the following: {', '.join(self.required_mem_opts)}")
+
+
 
 
 SlurmOptionsSchema = OmegaConf.structured(SlurmOptions)

--- a/stimela/backends/utils.py
+++ b/stimela/backends/utils.py
@@ -61,9 +61,16 @@ def resolve_required_mounts(params: Dict[str, Any],
             must_exist = name in inputs            
         readwrite = schema.writable or name in outputs
 
-        # for symlink targets, we need to mount the parent directory
         for path in files:
-            add_target(path, must_exist=must_exist, readwrite=readwrite)
+            path = path.rstrip("/")
+            # check parent access
+            if schema.access_parent_dir or schema.write_parent_dir:
+                add_target(os.path.dirname(path), must_exist=True, readwrite=schema.write_parent_dir)
+            # for symlink targets, we need to mount the parent directory
+            if os.path.islink(path):
+                add_target(os.path.dirname(path), must_exist=True, readwrite=readwrite)
+            else:
+                add_target(path, must_exist=must_exist, readwrite=readwrite)
 
     
     # now eliminate unnecessary targets (those that have a parent mount with the same read/write property)

--- a/stimela/commands/build.py
+++ b/stimela/commands/build.py
@@ -28,17 +28,13 @@ from stimela.main import cli
                 help="""explicitly skips steps wth the given tags. 
                 Use commas, or give multiple times for multiple tags.""")
 @click.option("-e", "--enable-step", "enable_steps", metavar="STEP(s)", multiple=True,
-                help="""Force-enable steps even if the recipe marks them as skipped. Use commas, or give multiple times 
+                help="""Build image for step(s) even if the recipe marks them as skipped. Use commas, or give multiple times 
                 for multiple steps.""")
-@click.option("-a", "--assign", metavar="PARAM VALUE", nargs=2, multiple=True,
-                help="""assigns values to parameters: equivalent to PARAM=VALUE, but plays nicer with the shell's 
-                tab completion.""")
 @click.option("-l", "--last-recipe", is_flag=True,
                 help="""if multiple recipes are defined, selects the last one for building.""")
 @click.argument("what", metavar="filename.yml|cab name") 
 def build(what: str, last_recipe: bool = False, rebuild: bool = False, all_steps: bool=False,
-            assign: List[Tuple[str, str]] = [],
             step_ranges: List[str] = [], tags: List[str] = [], skip_tags: List[str] = [], enable_steps: List[str] = []):
-    return run.callback(what, last_recipe=last_recipe, assign=assign, step_ranges=step_ranges, 
+    return run.callback(what, last_recipe=last_recipe, step_ranges=step_ranges, 
         tags=tags, skip_tags=skip_tags, enable_steps=enable_steps,
         build=True, rebuild=rebuild, build_skips=all_steps)

--- a/stimela/commands/build.py
+++ b/stimela/commands/build.py
@@ -14,13 +14,15 @@ from stimela.main import cli
     """,
     no_args_is_help=True)
 @click.option("-r", "--rebuild", is_flag=True,
-                help="""rebuilds all images from scratch.""")
+                help="""rebuilds all images from scratch. Default builds missing images only.""")
+@click.option("-a", "--all-steps", is_flag=True,
+                help="""builds images for all steps. Default is to omit explicitly skipped steps.""")
 @click.option("-s", "--step", "step_ranges", metavar="STEP(s)", multiple=True,
-                help="""only look at specific step(s) from the recipe. Use commas, or give multiple times to cherry-pick steps.
+                help="""only build images for specific step(s) from the recipe. Use commas, or give multiple times to cherry-pick steps.
                 Use [BEGIN]:[END] to specify a range of steps. Note that cherry-picking an individual step via this option
                 also impies --enable-step.""")
 @click.option("-t", "--tags", "tags", metavar="TAG(s)", multiple=True,
-                help="""only look at steps wth the given tags (and also steps tagged as "always"). 
+                help="""only build images for steps wth the given tags (and also steps tagged as "always"). 
                 Use commas, or give multiple times for multiple tags.""")
 @click.option("--skip-tags", "skip_tags", metavar="TAG(s)", multiple=True,
                 help="""explicitly skips steps wth the given tags. 
@@ -34,9 +36,9 @@ from stimela.main import cli
 @click.option("-l", "--last-recipe", is_flag=True,
                 help="""if multiple recipes are defined, selects the last one for building.""")
 @click.argument("what", metavar="filename.yml|cab name") 
-def build(what: str, last_recipe: bool = False, rebuild: bool = False, 
+def build(what: str, last_recipe: bool = False, rebuild: bool = False, all_steps: bool=False,
             assign: List[Tuple[str, str]] = [],
             step_ranges: List[str] = [], tags: List[str] = [], skip_tags: List[str] = [], enable_steps: List[str] = []):
     return run.callback(what, last_recipe=last_recipe, assign=assign, step_ranges=step_ranges, 
         tags=tags, skip_tags=skip_tags, enable_steps=enable_steps,
-        build=True, rebuild=rebuild)
+        build=True, rebuild=rebuild, build_skips=all_steps)

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -1128,14 +1128,14 @@ class Recipe(Cargo):
 
         return task_stats.collect_stats(), outputs, exception, tb
 
-    def build(self, backend={}, rebuild=False, log: Optional[logging.Logger] = None):
+    def build(self, backend={}, rebuild=False, build_skips=False, log: Optional[logging.Logger] = None):
         # set up backend
         backend = OmegaConf.merge(backend, self.backend or {})
         # build recursively
         log = log or self.log
         log.info(f"building image(s) for recipe '{self.fqname}'")
         for step in self.steps.values():
-            step.build(backend, rebuild=rebuild, log=log)
+            step.build(backend, rebuild=rebuild, build_skips=build_skips, log=log)
 
 
     def _run(self, params, subst=None, backend={}) -> Dict[str, Any]:

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -261,7 +261,7 @@ class Step:
                 backend or {}, 
                 self.cargo.backend or {}, 
                 self.backend or {}))
-            runner.validate_backend_settings(backend_opts)
+            runner.validate_backend_settings(backend_opts, log=log)
 
 
     def prevalidate(self, subst: Optional[SubstitutionNS]=None, root=False):
@@ -332,7 +332,7 @@ class Step:
             try:
                 backend = OmegaConf.merge(backend, self.cargo.backend or {}, self.backend or {})
                 backend = OmegaConf.to_object(OmegaConf.merge(StimelaBackendSchema, backend))
-                backend_wrapper = runner.validate_backend_settings(backend)
+                backend_wrapper = runner.validate_backend_settings(backend, log=log)
             except Exception as exc:
                 newexc = BackendError("error validating backend settings", exc)
                 raise newexc from None
@@ -354,7 +354,7 @@ class Step:
             backend = OmegaConf.merge(backend, self.cargo.backend or {}, self.backend or {})
             backend_opts = evaluate_and_substitute_object(backend, subst, recursion_level=-1, location=[self.fqname, "backend"])
             backend_opts = OmegaConf.to_object(OmegaConf.merge(StimelaBackendSchema, backend_opts))
-            backend_wrapper = runner.validate_backend_settings(backend_opts)
+            backend_wrapper = runner.validate_backend_settings(backend_opts, log=self.log)
         except Exception as exc:
             newexc = BackendError("error validating backend settings", exc)
             raise newexc from None

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -317,15 +317,15 @@ class Step:
                 raise AssignmentError(f"{self.name}: invalid assignment {key}={value}", exc)
 
 
-    def build(self, backend={}, rebuild=False, log: Optional[logging.Logger] = None):
+    def build(self, backend={}, rebuild=False, build_skips=False, log: Optional[logging.Logger] = None):
         # skipping step? ignore the build
-        if self.skip is True:
+        if self.skip is True and not build_skips:
             return
         log = log or self.log
         # recurse into sub-recipe 
         from .recipe import Recipe
         if type(self.cargo) is Recipe:
-            return self.cargo.build(backend, rebuild=rebuild, log=log)
+            return self.cargo.build(backend, rebuild=rebuild, build_skips=build_skips, log=log)
         # else build 
         else:
             # validate backend settings and call the build function

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -184,6 +184,9 @@ def logger(name="STIMELA", propagate=False, boring=False, loglevel="INFO"):
 _logger_file_handlers = {}
 _logger_console_handlers = {}
 
+# keep track of all log files opened
+_previous_logfiles = set()
+
 
 def has_file_logger(log: logging.Logger):
     return log.name in _logger_file_handlers
@@ -247,9 +250,14 @@ def setup_file_logger(log: logging.Logger, logfile: str, level: Optional[Union[i
         if fh is not None:
             fh.close()
             log.removeHandler(fh)
-
+        # if file was previously open, append, else overwrite
+        if logfile in _previous_logfiles:
+            mode = 'a'
+        else:
+            mode = 'w'
+            _previous_logfiles.add(logfile)
         # create new FH
-        fh = DelayedFileHandler(logfile, symlink, 'w')
+        fh = DelayedFileHandler(logfile, symlink, mode)
         fh.setFormatter(log_boring_formatter)
         log.addHandler(fh)
 

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -17,9 +17,7 @@ from rich.markup import escape
 from rich.padding import Padding
 
 from . import task_stats
-from .task_stats import declare_subtask, declare_subtask_attributes, \
-                        declare_subcommand, update_process_status, \
-                        run_process_status_update
+from .task_stats import declare_subcommand, declare_subtask, declare_subtask_attributes, run_process_status_update
 
 class FunkyMessage(object):
     """Class representing a message with two versions: funky (with markup), and boring (no markup)"""


### PR DESCRIPTION
Please review and merge #207 first, as this is based off that branch.

Adds bindings of non-current paths into singularity, fixing #189 which tripped up @Athanaseus a few times.

Also adds ``access_parent_dir`` and ``write_parent_dir`` fields to Parameter. I quickly realized this was needed for "funny" stuff like CASA flagman (because if it's accessing ``foo/bar.MS``, it also needs access to ``foo/`` itself, so it can create the flagversions table alongside the MS).