### PR TITLE
fixes profiling and progress bar for scattered for-loops

### DIFF
--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -8,7 +8,7 @@ from contextlib import nullcontext
 
 from stimela.config import EmptyDictDefault, EmptyListDefault
 import stimela
-from stimela import log_exception, stimelogging
+from stimela import log_exception, stimelogging, task_stats
 from stimela.backends import StimelaBackendSchema, runner
 from stimela.exceptions import *
 import scabha.exceptions
@@ -337,7 +337,7 @@ class Step:
                 newexc = BackendError("error validating backend settings", exc)
                 raise newexc from None
             log.info(f"building image for step '{self.fqname}'")
-            with stimelogging.declare_subtask(self.name):
+            with task_stats.declare_subtask(self.name):
                 return backend_wrapper.build(self.cargo, log=log, rebuild=rebuild)
 
 
@@ -365,7 +365,7 @@ class Step:
             context = nullcontext()
             parent_log_info = parent_log_warning = parent_log.debug
         else:
-            context = stimelogging.declare_subtask(self.name, hide_local_metrics=backend_wrapper.is_remote)
+            context = task_stats.declare_subtask(self.name, hide_local_metrics=backend_wrapper.is_remote)
             stimelogging.declare_chapter(f"{self.fqname}")
             parent_log_info, parent_log_warning = parent_log.info, parent_log.warning
 

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -17,7 +17,6 @@ from rich.markup import escape
 from rich.padding import Padding
 
 from . import task_stats
-from .task_stats import declare_subcommand, declare_subtask, declare_subtask_attributes, run_process_status_update
 
 class FunkyMessage(object):
     """Class representing a message with two versions: funky (with markup), and boring (no markup)"""


### PR DESCRIPTION
@Athanaseus try this one, the profiling looks a lot better (at least in terms of time elapsed).

Mind you, we can't really measure any CPU load and such on remote nodes, so those stats are useless. But the elapsed times are useful.

