### PR TITLE
Add recursive finder for filelike objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pydantic = "^1.10.2"
 psutil = "^5.9.3"
 rich = "^13.7.0"
 dill = "^0.3.6"
+typeguard = "^4.2.1"
 
 [tool.poetry.scripts]
 stimela = "stimela.main:cli"

--- a/scabha/basetypes.py
+++ b/scabha/basetypes.py
@@ -1,9 +1,12 @@
 from dataclasses import field, dataclass
 from collections import OrderedDict
-from typing import List
+from typing import List, Union, get_args, get_origin
 import os.path
 import re
 from .exceptions import UnsetError
+from itertools import zip_longest
+from typeguard import check_type, TypeCheckError
+
 
 def EmptyDictDefault():
     return field(default_factory=lambda:OrderedDict())
@@ -55,7 +58,7 @@ class URI(str):
     def parse(value: str, expand_user=True):
         """
         Parses URI. If URI does not start with "protocol://", assumes "file://"
-        
+
         Returns tuple of (protocol, path, is_remote)
 
         If expand_user is True, ~ in (file-protocol) paths will be expanded.
@@ -75,7 +78,7 @@ class File(URI):
     @property
     def NAME(self):
         return File(os.path.basename(self))
-    
+
     @property
     def PATH(self):
         return File(os.path.abspath(self))
@@ -95,7 +98,7 @@ class File(URI):
     @property
     def EXT(self):
         return os.path.splitext(self)[1]
-    
+
     @property
     def EXISTS(self):
         return os.path.exists(self)
@@ -114,3 +117,64 @@ def is_file_type(dtype):
 def is_file_list_type(dtype):
     return any(dtype == List[t] for t in FILE_TYPES)
 
+
+class Skip(object):
+    def iterate_samples(self, collection):
+        return ()
+
+
+def get_filelikes(dtype, value, filelikes=None):
+    """Recursively recover all filelike elements from a composite dtype."""
+
+    filelikes = set() if filelikes is None else filelikes
+
+    origin = get_origin(dtype)
+    args = get_args(dtype)
+
+    if origin:  # Implies composition.
+
+        if origin is dict:
+
+            # No further work required for empty collections.
+            if len(value) == 0:
+                return filelikes
+
+            k_dtype, v_dtype = args
+
+            for k, v in value.items():
+                filelikes = get_filelikes(k_dtype, k, filelikes)
+                filelikes = get_filelikes(v_dtype, v, filelikes)
+
+        elif origin in (tuple, list, set):
+
+            # No further work required for empty collections.
+            if len(value) == 0:
+                return filelikes
+
+            # This is a special case for tuples of arbitrary
+            # length i.e. list-like behaviour.
+            if ... in args:
+                args = tuple([a for a in args if a != ...])
+
+            for dt, v in zip_longest(args, value, fillvalue=args[0]):
+                filelikes = get_filelikes(dt, v, filelikes)
+
+        elif origin is Union:
+
+            for dt in args:
+
+                try:
+                    # Do not check collection member types. 
+                    check_type(value, dt, collection_check_strategy=Skip())
+                except TypeCheckError:
+                    continue
+                filelikes = get_filelikes(dt, value, filelikes)
+
+        else:
+            raise ValueError(f"Failed to traverse {dtype} dtype when looking for files.")
+
+    else:
+        if is_file_type(dtype):
+            filelikes.add(value)
+
+    return filelikes

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -256,6 +256,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
     mounts = {cwd: True}
     # add extra binds
     for path, rw in backend.singularity.bind_dirs.items():
+        path = os.path.expanduser(path)
         mounts[path] = mounts.get(path, False) or (rw == ReadWriteMode.rw)
 
     # get extra required filesystem bindings

--- a/stimela/backends/utils.py
+++ b/stimela/backends/utils.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Any, Dict
 from stimela.kitchen.cab import Cab, Parameter
 from scabha.exceptions import SchemaError
 from stimela.exceptions import BackendError
-from scabha.basetypes import File, Directory, MS, URI
+from scabha.basetypes import File, Directory, MS, URI, get_filelikes
 
 ## commenting out for now -- will need to fix when we reactive the kube backend (and have tests for it)
 
@@ -34,11 +34,9 @@ def resolve_required_mounts(mounts: Dict[str, bool],
         if schema is None:
             raise SchemaError(f"parameter {name} not in defined inputs or outputs for this cab. This should have been caught by validation earlier!")
 
-        if schema.is_file_type:
-            files = [value]
-        elif schema.is_file_list_type:
-            files = value
-        else:
+        files = get_filelikes(schema._dtype, value)
+
+        if not files:
             continue
 
         must_exist = schema.must_exist and name in inputs 

--- a/tests/scabha_tests/test_filelikes.py
+++ b/tests/scabha_tests/test_filelikes.py
@@ -1,0 +1,42 @@
+from scabha.basetypes import get_filelikes, File, URI, Directory, MS
+from typing import Dict, List, Set, Tuple, Union, Optional
+import pytest
+
+
+@pytest.fixture(scope="module", params=[File, URI, Directory, MS])
+def templates(request):
+    
+    ft = request.param
+    
+    TEMPLATES = (
+        (Tuple, (), set()),
+        (Tuple[int, ...], [1, 2], set()),
+        (Tuple[ft, ...], ("foo", "bar"), {"foo", "bar"}),
+        (Tuple[ft, str], ("foo", "bar"), {"foo"}),
+        (Dict[str, int], {"a": 1, "b": 2}, set()),
+        (Dict[str, ft], {"a": "foo", "b": "bar"}, {"foo", "bar"}),
+        (Dict[ft, str], {"foo": "a", "bar": "b"}, {"foo", "bar"}),
+        (List[ft], [], set()),
+        (List[int], [1, 2], set()),
+        (List[ft], ["foo", "bar"], {"foo", "bar"}),
+        (Set[ft], set(), set()),
+        (Set[int], {1, 2}, set()),
+        (Set[ft], {"foo", "bar"}, {"foo", "bar"}),
+        (Union[str, List[ft]], "foo", set()),
+        (Union[str, List[ft]], ["foo"], {"foo"}),
+        (Union[str, Tuple[ft]], "foo", set()),
+        (Union[str, Tuple[ft]], ("foo",), {"foo"}),
+        (Optional[ft], None, set()),
+        (Optional[ft], "foo", {"foo"}),
+        (Optional[Union[ft, int]], 1, set()),
+        (Optional[Union[ft, int]], "foo", {"foo"}),
+        (Dict[str, Tuple[ft, str]], {"a": ("foo", "bar")}, {"foo"})
+    )
+
+    return TEMPLATES
+
+
+def test_get_filelikes(templates):
+
+    for dt, v, res in templates:
+        assert get_filelikes(dt, v) == res, f"Failed for dtype {dt} and value {v}."


### PR DESCRIPTION
(Hopefully) does what it says on the tin. As @o-smirnov points out, this may be somewhat error prone. That said, I have added a handful of tests and the pipeline which originally identified the problem now runs through. In principle, the code could be further refined (the `typeguard` package seems to be very useful), but I think that this should be enough for now. If more exotic types foil this approach, we can always add them to the test suite and iterate.