### PR TITLE
Escape messages before emitting.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stimela"
-version = "2.0rc17"
+version = "2.0rc18"
 description = "Framework for system agnostic pipelines for (not just) radio interferometry"
 authors = ["Sphesihle Makhathini <sphemakh@gmail.com>", "Oleg Smirnov and RATT <osmirnov@gmail.com>"]
 readme = "README.rst"

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -5,7 +5,7 @@ from omegaconf import MISSING, OmegaConf, DictConfig, ListConfig
 from omegaconf.errors import OmegaConfBaseException
 from collections import OrderedDict
 from contextlib import nullcontext
-from rich.syntax import Syntax
+from rich.markup import escape
 
 from stimela.config import EmptyDictDefault, EmptyListDefault
 import stimela
@@ -287,7 +287,7 @@ class Step:
         if self.log.isEnabledFor(level):
             self.log.log(level, f"### {title}", extra=extra)
             for line in self.summary(recursive=False, inputs=inputs, outputs=outputs, ignore_missing=ignore_missing):
-                self.log.log(level, line, extra=extra)
+                self.log.log(level, escape(line), extra=extra)
 
     def log_exception(self, exc, severity="error", log=None):
         log_exception(exc, severity=severity, log=log or self.log)

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -47,14 +47,20 @@ class StimelaConsoleHander(rich.logging.RichHandler):
         self._console = console
 
     def emit(self, record):
-        record.msg = escape(record.msg)  # Escape message contents.
         try:
             rich.logging.RichHandler.emit(self, record)
+        # backstop -- message should have been properly markup-escaped
         except MarkupError:
-            self._console.print(f"Malformed markup in {record.msg}.", markup=False, style="yellow")
-        else:
-            if hasattr(record, 'console_payload'):
-                self._console.print(record.console_payload, highlight=getattr(record, 'console_highlight', None))
+            record.msg = escape(record.msg)
+            self._console.print(f"Malformed markup in log message: {record.msg}", markup=False, style="red")
+            self._console.print(f"This is a (probably harmless) bug -- but please report", markup=False, style="red")
+            try:
+                rich.logging.RichHandler.emit(self, record)
+            except MarkupError:
+                self._console.print(f"Malformed markup after escaping -- this is surely a bug -- please report", markup=False, style="red")
+
+        if hasattr(record, 'console_payload'):
+            self._console.print(record.console_payload, highlight=getattr(record, 'console_highlight', None))
 
 class StimelaLogFormatter(logging.Formatter):
     DEBUG_STYLE   = "dim", ""


### PR DESCRIPTION
This is a potential (but possibly imperfect) fix for log messages containing characters which could be misinterpreted as markup tags. This issue was uncovered when specifying a list of absolute paths. Specifically, `[\path]` will be misinterpreted as a markup tag and cause `stimela` to crash.