### PR TITLE
Drop Python3.7 support - heavily deprecated upstream.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 munch = "^2.5.0"
 omegaconf = "^2.1"
 importlib_metadata = { version = "4.13.0", python = "3.7" }


### PR DESCRIPTION
Python3.7 is becoming very difficult to support as it has been dropped by upstream packages. I suggest removing it before the 2.0 release.