### PR TITLE
Attempt at making substitutions work inside dicts and lists.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stimela"
-version = "2.0rc17"
+version = "2.0rc18"
 description = "Framework for system agnostic pipelines for (not just) radio interferometry"
 authors = ["Sphesihle Makhathini <sphemakh@gmail.com>", "Oleg Smirnov and RATT <osmirnov@gmail.com>"]
 readme = "README.rst"

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -625,6 +625,31 @@ class Evaluator(object):
                         params_out[name] = new_value
                         if corresponding_ns:
                             corresponding_ns[name] = new_value
+                elif isinstance(value, (dict, DictConfig)):
+                    params_out[name] = self.evaluate_dict(
+                        value,
+                        corresponding_ns,
+                        defaults,
+                        sublocation,
+                        raise_substitution_errors,
+                        recursive,
+                        verbose
+                    )
+                elif isinstance(value, list):
+                    params_out[name] = type(value)(
+                        [
+                            self.evaluate_dict(
+                                {"dummy": v},
+                                corresponding_ns,
+                                defaults,
+                                sublocation,
+                                raise_substitution_errors,
+                                recursive,
+                                verbose
+                            )["dummy"] for v in value
+                        ]
+                    )
+
         return params_out
 
 

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -635,18 +635,18 @@ class Evaluator(object):
                         recursive,
                         verbose
                     )
-                elif isinstance(value, list):
+                elif isinstance(value, (list, ListConfig)):
                     params_out[name] = type(value)(
                         [
-                            self.evaluate_dict(
-                                {"dummy": v},
+                            ele for ele in self.evaluate_dict(
+                                {f"[{i}]": v for i, v in enumerate(value)},
                                 corresponding_ns,
                                 defaults,
                                 sublocation,
                                 raise_substitution_errors,
                                 recursive,
                                 verbose
-                            )["dummy"] for v in value
+                            ).values()
                         ]
                     )
 

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -638,7 +638,7 @@ class Evaluator(object):
                 elif isinstance(value, (list, ListConfig)):
                     params_out[name] = type(value)(
                         [
-                            ele for ele in self.evaluate_dict(
+                            *self.evaluate_dict(
                                 {f"[{i}]": v for i, v in enumerate(value)},
                                 corresponding_ns,
                                 defaults,

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -580,7 +580,7 @@ class Evaluator(object):
                     defaults: Dict[str, Any] = {}, 
                     sublocation = [],
                     raise_substitution_errors: bool = True, 
-                    recursive: bool = False,
+                    recursive: bool = True,
                     verbose: bool = False):
         params_out = params
         for name, value in list(params.items()):
@@ -625,27 +625,27 @@ class Evaluator(object):
                         params_out[name] = new_value
                         if corresponding_ns:
                             corresponding_ns[name] = new_value
-                elif isinstance(value, (dict, DictConfig)):
+                elif isinstance(value, (dict, DictConfig)) and recursive:
                     params_out[name] = self.evaluate_dict(
                         value,
                         corresponding_ns,
                         defaults,
-                        sublocation,
-                        raise_substitution_errors,
-                        recursive,
-                        verbose
+                        sublocation=sublocation + [name],
+                        raise_substitution_errors=raise_substitution_errors,
+                        recursive=True,
+                        verbose=verbose
                     )
-                elif isinstance(value, (list, ListConfig)):
+                elif isinstance(value, (list, ListConfig)) and recursive:
                     params_out[name] = type(value)(
                         [
                             *self.evaluate_dict(
                                 {f"[{i}]": v for i, v in enumerate(value)},
                                 corresponding_ns,
                                 defaults,
-                                sublocation,
-                                raise_substitution_errors,
-                                recursive,
-                                verbose
+                                sublocation=sublocation + [name],
+                                raise_substitution_errors=raise_substitution_errors,
+                                recursive=True,
+                                verbose=verbose
                             ).values()
                         ]
                     )

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -291,6 +291,7 @@ def update_file_logger(log: logging.Logger, logopts: DictConfig, nesting: int = 
         setup_file_logger(log, path, level=logopts.level, symlink=logopts.symlink)
     else:
         disable_file_logger(log)
+        log.propagate = True
 
 
 def get_logfile_dir(log: logging.Logger):


### PR DESCRIPTION
This PR aims to improve substitutions by supporting them inside compound types. This probably needs extensive testing, but the following should now work:
```yaml
inputs:
  foo:  # foo is Dict[str, Tuple[File, float, str]] type.
    bar: [=expression_with_substitution, 1, example]  
```
or equivalently:
```yaml
inputs:
  foo:   # foo is Dict[str, Tuple[File, float, str]] type.
    bar: =LIST(substitution, 1, "example")
```
This should also support more complicated cases e.g.:
```yaml
inputs:
  foo:   # foo is List[Dict[str, Tuple[File, float, str]]] type.
    bar: 
      - baz: [=expression_with_substitution, 1, example]
```
