### PR TITLE
fixes #273. Adds schema flattening to clickify_parameters

### DIFF
--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -88,6 +88,7 @@ class ParameterPolicies(object):
     pass_missing_as_none: Optional[bool] = None
 
 
+
 # This is used to classify parameters, for cosmetic and help purposes.
 # Usually set automatically based on whether a parameter is required, whether a default is provided, etc.
 ParameterCategory = IntEnum("ParameterCategory",
@@ -161,6 +162,11 @@ class Parameter(object):
 
     # arbitrary metadata associated with parameter
     metadata: Dict[str, Any] = EmptyDictDefault()
+    
+    # If True, when constructing a CLI from the schema, omit the default value (if any).
+    # Useful when the tool constructs itw own default values.
+    suppress_cli_default: bool = False
+
 
 
     def __post_init__(self):

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -148,6 +148,9 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]]):
     if type(schemas) is str:
         schemas = OmegaConf.merge(OmegaConf.structured(Schema),
                                 OmegaConf.load(schemas))
+    else:
+        schemas = OmegaConf.merge(OmegaConf.structured(Schema),
+                                  dict(inputs=schemas.inputs, outputs=schemas.outputs))
 
     decorator_chain = None
     inputs = Cargo.flatten_schemas(OrderedDict(), schemas.inputs, "inputs")


### PR DESCRIPTION
See #273. Also added schema flattening to clickify_parameters(). This should be a no-op for existing users.