### PR TITLE
fixes #275

### DIFF
--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -125,15 +125,35 @@ def nested_schema_to_dataclass(nested: Dict[str, Dict], class_name: str, bases=(
 
 _atomic_types = dict(bool=bool, str=str, int=int, float=float)
 
-def _validate_list(text: str, element_type, schema):
+def _validate_list(text: str, element_type, schema, sep=",", brackets=True):
     if not text:
         return schema.default
-    if text == "[]":
-        return []
-    if text[0] == "[" and text[-1] == "]":
+    if brackets:
+        if text == "[]":
+            return []
+        if text[0] != "[" or text[-1] != "]":
+            raise click.BadParameter(f"can't convert to '{schema.dtype}', missing '[]' brackets")
         text = text[1:-1]
     try:
-        return [element_type(x) for x in text.split(",")]
+        return list(element_type(x) for x in text.split(sep))
+    except ValueError:
+        raise click.BadParameter(f"can't convert to '{schema.dtype}'")
+
+def _validate_tuple(text: str, element_types, schema, sep=",", brackets=True):
+    if not text:
+        return schema.default
+    print(text, element_types)
+    if brackets:
+        if text == "[]":
+            return []
+        if text[0] != "[" or text[-1] != "]":
+            raise click.BadParameter(f"can't convert to '{schema.dtype}', missing '[]' brackets")
+        text = text[1:-1]
+    elems = text.split(sep)
+    if len(elems) != len(element_types):
+        raise click.BadParameter(f"can't convert to '{schema.dtype}', tuple length mismatch")
+    try:
+        return tuple(element_type(x) for x, element_type in zip(elems, element_types))
     except ValueError:
         raise click.BadParameter(f"can't convert to '{schema.dtype}'")
 
@@ -148,23 +168,22 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]]):
     if type(schemas) is str:
         schemas = OmegaConf.merge(OmegaConf.structured(Schema),
                                 OmegaConf.load(schemas))
-    else:
-        schemas = OmegaConf.merge(OmegaConf.structured(Schema),
-                                  dict(inputs=schemas.inputs, outputs=schemas.outputs))
 
     decorator_chain = None
-    inputs = Cargo.flatten_schemas(OrderedDict(), schemas.inputs, "inputs")
-    outputs = Cargo.flatten_schemas(OrderedDict(), schemas.outputs, "outputs")
+    inputs = Cargo.flatten_schemas(OrderedDict(), getattr(schemas, 'inputs', {}), "inputs")
+    outputs = Cargo.flatten_schemas(OrderedDict(), getattr(schemas, 'outputs', {}), "outputs")
     for io in inputs, outputs:
         for name, schema in io.items():
             # skip outputs, unless they're named outputs
-            if io is schemas.outputs and not (schema.is_file_type and not schema.implicit):
+            if io is outputs and not (schema.is_file_type and not schema.implicit):
                 continue
 
             name = name.replace("_", "-").replace(".", "-")
             optname = f"--{name}"
             dtype = schema.dtype
             validator = None
+            multiple = False
+            nargs = 1
 
             # sort out option type. Atomic type?
             if dtype in _atomic_types:
@@ -175,16 +194,51 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]]):
             elif dtype in ("MS", "File", "Directory"):
                 dtype = click.Path(exists=(io is schemas.inputs))
             else:
-                match = re.fullmatch("List\[(.*)\]", dtype)
+                list_match = re.fullmatch("List\[(.*)\]", dtype)
+                tuple_match = re.fullmatch("Tuple\[(.*)\]", dtype)
                 # List[x] type? Add validation callback to convert elements
-                if match:
-                    elem_type_name = match.group(1)
-                    # convert "x" to type object -- unknown element types will get treated as a string
-                    elem_type = _atomic_types.get(elem_type_name, str)
-                    validator = lambda ctx, param, value, etype=elem_type, schema=schema: _validate_list(value, element_type=etype, schema=schema)
-                # anything else will be just a string
-                dtype = str
+                if list_match:
+                    elem_type = _atomic_types.get(list_match.group(1).strip(), str)
+                    if schema.policies.repeat == 'list':
+                        nargs = -1
+                        dtype = elem_type
+                    elif schema.policies.repeat == 'repeat':
+                        multiple = True
+                        dtype = elem_type
+                    elif schema.policies.repeat == '[]':  # else assume [X,Y] or X,Y syntax
+                        dtype = str
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema: \
+                            _validate_list(value, element_type=elem_type, schema=schema)
+                    elif schema.policies.repeat is not None:  # assume XrepY syntax
+                        dtype = str
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema: \
+                            _validate_list(value, element_type=elem_type, schema=schema, 
+                                           sep=schema.policies.repeat, brackets=False)
+                    else:
+                        raise SchemaError(f"list-type parameter '{name}' does not have a repeat policy set")
+                elif tuple_match:
+                    elem_types = tuple(_atomic_types.get(t.strip(), str) for t in tuple_match.group(1).split(","))
+                    if schema.policies.repeat == 'list' or schema.policies.repeat == 'repeat':
+                        nargs = len(elem_types)
+                        #multiple = True
+                        dtype = elem_types
+                    elif schema.policies.repeat == '[]':  # else assume [X,Y] or X,Y syntax
+                        dtype = str
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema: \
+                            _validate_tuple(value, element_types=elem_types, schema=schema)
+                    elif schema.policies.repeat is not None:  # assume XrepY syntax
+                        dtype = str
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema: \
+                            _validate_tuple(value, element_types=elem_types, schema=schema,
+                                           sep=schema.policies.repeat, brackets=False)
+                    else:
+                        raise SchemaError(f"tuple-type parameter '{name}' does not have a repeat policy set")
+                else:
+                    # anything else will be just a string
+                    dtype = str
 
+            # if name == 'catalogs':
+            #     print(f"catalogs: {dtype}")
             # choices?
             if schema.choices:
                 dtype = click.Choice(schema.choices)
@@ -195,30 +249,24 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]]):
                 optnames.append(f"-{schema.abbreviation}")
 
             if schema.policies.positional:
-                if schema.default in (UNSET, _UNSET_DEFAULT) or schema.suppress_cli_default:
-                    deco = click.argument(name, type=dtype, callback=validator,
-                                        required=schema.required,
-                                        metavar=schema.metavar)
-                else:
-                    deco = click.argument(name, type=dtype, callback=validator,
-                                        default=schema.default, required=schema.required,
-                                        metavar=schema.metavar)
+                kwargs = dict(type=dtype, callback=validator, required=schema.required, nargs=nargs,
+                              metavar=schema.metavar)
+                if not schema.default in (UNSET, _UNSET_DEFAULT) and not schema.suppress_cli_default:
+                    kwargs['default'] = schema.default
+                deco = click.argument(name, **kwargs)
             else:
-                if schema.default in (UNSET, _UNSET_DEFAULT) or schema.suppress_cli_default:
-                    deco = click.option(*optnames, type=dtype, callback=validator,
-                                        required=schema.required,
-                                        metavar=schema.metavar, help=schema.info)
-                else:
-                    deco = click.option(*optnames, type=dtype, callback=validator,
-                                        default=schema.default, required=schema.required,
-                                        metavar=schema.metavar, help=schema.info)
-
+                kwargs = dict(type=dtype, callback=validator,
+                              required=schema.required, multiple=multiple,
+                              metavar=schema.metavar, help=schema.info)
+                if not schema.default in (UNSET, _UNSET_DEFAULT) and not schema.suppress_cli_default:
+                    kwargs['default'] = schema.default
+                deco = click.option(*optnames, **kwargs)
             if decorator_chain is None:
                 decorator_chain = deco
             else:
                 decorator_chain = lambda x,deco=deco,chain=decorator_chain: chain(deco(x))
 
-    return decorator_chain
+    return decorator_chain or (lambda x: x)
 
 @dataclass
 class SchemaSpec:

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -250,8 +250,6 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]],
                     # anything else will be just a string
                     dtype = str
 
-            # if name == 'catalogs':
-            #     print(f"catalogs: {dtype}")
             # choices?
             if schema.choices:
                 dtype = click.Choice(schema.choices)

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -142,7 +142,6 @@ def _validate_list(text: str, element_type, schema, sep=",", brackets=True):
 def _validate_tuple(text: str, element_types, schema, sep=",", brackets=True):
     if not text:
         return schema.default
-    print(text, element_types)
     if brackets:
         if text == "[]":
             return []


### PR DESCRIPTION
@landmanbester could you please test that this branch does not break pfb-clean CLIs?

The change is that ``policies.repeat`` is now properly honoured for List and Tuple types, to accommodate the different styles of passing multiple values. As [per documentation](https://stimela.readthedocs.io/en/latest/reference/policies.html):

* ``repeat: list`` uses ``--option X Y``
* ``repeat: repeat`` uses ``--option X --option Y``
* ``repeat: '[]'`` uses ``--option [X,Y]``
* ``repeat: ','`` (or any other separator string) uses ``--option X,Y``

There is no default for the repeat policy, and ``clickify_parameters`` will raise an error if this is not explicitly specified for List and Tuple types. This may perhaps be an annoyance, and I'm open to using a default instead, but which one?
