### PR TITLE
Some tiny fixes and improvements for kube backend + dask clusters.

### DIFF
--- a/stimela/backends/kube/daskjob.py
+++ b/stimela/backends/kube/daskjob.py
@@ -95,6 +95,8 @@ def split_args(args):
 def daskjob_template(args):
     labels = dict(args.labels)
 
+    env_var = [{"name": k, "value": v} for k, v in args.environment_variables.items()]
+
     return {
         "apiVersion": "kubernetes.dask.org/v1",
         "kind": "DaskJob",
@@ -133,7 +135,8 @@ def daskjob_template(args):
                                         {
                                             "name": "SCHEDULER_ENV",
                                             "value": "hello-world",
-                                        }
+                                        },
+                                        *env_var
                                     ],
                                     "image": args.image,
                                     "imagePullPolicy": args.pull_policy,
@@ -186,7 +189,11 @@ def daskjob_template(args):
                                         "$(DASK_SCHEDULER_ADDRESS)",
                                     ],
                                     "env": [
-                                        {"name": "WORKER_ENV", "value": "hello-world"}
+                                        {
+                                            "name": "WORKER_ENV",
+                                            "value": "hello-world"
+                                        },
+                                        *env_var
                                     ],
                                     "image": args.image,
                                     "imagePullPolicy": args.pull_policy,

--- a/stimela/backends/kube/infrastructure.py
+++ b/stimela/backends/kube/infrastructure.py
@@ -39,6 +39,7 @@ def _delete_pod(kube_api, podname, namespace, log, warn_not_found=True):
     log.info(f"deleting pod {podname}")
     try:
         resp = kube_api.delete_namespaced_pod(name=podname, namespace=namespace)
+        log.debug(f"delete_namespaced_pod({podname}): {resp}")
     except ApiException as exc:
         body = json.loads(exc.body)
         if "reason" in body and body["reason"] == "NotFound" and warn_not_found:
@@ -46,7 +47,6 @@ def _delete_pod(kube_api, podname, namespace, log, warn_not_found=True):
         else:
             log_exception(BackendError(f"k8s API error while deleting pod {podname}", (exc, body)), 
                         severity="error", log=log)
-    log.debug(f"delete_namespaced_pod({podname}): {resp}")
 
 def cleanup(backend: StimelaBackendOptions, log: logging.Logger):
     return init(backend, log, cleanup=True)

--- a/stimela/backends/kube/pod_proxy.py
+++ b/stimela/backends/kube/pod_proxy.py
@@ -118,7 +118,7 @@ class PodProxy(object):
         if self._session_init_container is None:
             self._session_init_container = dict(
                 name="volume-session-init",
-                image="busybox",
+                image="quay.io/quay/busybox",
                 command=["/bin/sh", "-c", ""],
                 volumeMounts=[])
             self.pod_spec.setdefault('initContainers', []).append(self._session_init_container)
@@ -129,7 +129,7 @@ class PodProxy(object):
         if self._step_init_container is None:
             self._step_init_container = dict(
                 name="volume-step-init",
-                image="busybox",
+                image="quay.io/quay/busybox",
                 command=["/bin/sh", "-c", ""],
                 securityContext=dict(
                         runAsNonRoot = self.uinfo.uid!=0,

--- a/stimela/backends/kube/run_kube.py
+++ b/stimela/backends/kube/run_kube.py
@@ -140,6 +140,7 @@ def run(cab: Cab, params: Dict[str, Any], fqname: str,
                     # cmdline=["/bin/sh", "-c", "while true;do date;sleep 5; done"],
                     service_account=kube.service_account,
                     mount_file=None,
+                    environment_variables=kube.env
                 )))
 
                 # apply pod type specifications


### PR DESCRIPTION
This PR includes:

- Propagation of environment variables specified in `kube` backend options into the `dask_cluster` worker and scheduler pods. This is needed to support e.g. `NUMBA_CACHE_DIR` when using a `dask_cluster`.
- Fix for a log message which was causing crashes as it referenced a potentially undefined variable.
- Replaces the `dockerhub` busybox images with the `quay.io` equivalents to circumvent rate limits (which come into play when pulling images onto hundreds of nodes).