### PR TITLE
fixes #284

### DIFF
--- a/scabha/configuratt/deps.py
+++ b/scabha/configuratt/deps.py
@@ -15,9 +15,9 @@ from .common import *
 @dataclass
 class FailRecord(object):
     filename: str
-    origin: Optional[str]
-    modulename: Optional[str]
-    fname: Optional[str]
+    origin: Optional[str] = None
+    modulename: Optional[str] = None
+    fname: Optional[str] = None
 
 @dataclass
 class RequirementRecord(object):

--- a/stimela/commands/doc.py
+++ b/stimela/commands/doc.py
@@ -133,14 +133,14 @@ def doc(what: List[str] = [], do_list=False, implicit=False, obscure=False, all=
             subtree = top_tree.add("Recipes:")
             table = Table.grid("", "", padding=(0,2))
             for name, recipe in stimela.CONFIG.lib.recipes.items():
-                table.add_row(f"[bold]{name}[/bold]", recipe.info)
+                table.add_row(f"[bold]{name}[/bold]", getattr(recipe, 'info', ''))
             subtree.add(table)
 
         if stimela.CONFIG.cabs:
             subtree = top_tree.add("Cabs:")
             table = Table.grid("", "", padding=(0,2))
             for name, cab in stimela.CONFIG.cabs.items():
-                table.add_row(f"[bold]{name}[/bold]", cab.info)
+                table.add_row(f"[bold]{name}[/bold]", getattr(cab, 'info', ''))
             subtree.add(table)            
         
     rich_print(top_tree)

--- a/stimela/commands/doc.py
+++ b/stimela/commands/doc.py
@@ -82,7 +82,7 @@ def doc(what: List[str] = [], do_list=False, implicit=False, obscure=False, all=
     
     # load config and recipes from all given files
     if files_to_load:
-        load_recipe_files(files_to_load)
+        top_level_recipes = load_recipe_files(files_to_load)
 
     destroy_progress_bar()
 
@@ -109,9 +109,10 @@ def doc(what: List[str] = [], do_list=False, implicit=False, obscure=False, all=
 
     # if nothing was specified, and only one cab/only one recipe is defined, print that
     if not names_to_document:
-        if len(stimela.CONFIG.lib.recipes) == 1 and not stimela.CONFIG.cabs:
-            recipes_to_document.update(stimela.CONFIG.lib.recipes.keys())
-        elif len(stimela.CONFIG.cabs) == 1 and not stimela.CONFIG.lib.recipes:
+        if len(top_level_recipes) == 1:
+            recipes_to_document.update(top_level_recipes)
+            log.info("a single top-level recipe is defined, documenting it by default. Use -l to list all defined recipes/cabs")
+        elif len(stimela.CONFIG.cabs) == 1 and not top_level_recipes:
             cabs_to_document.update(stimela.CONFIG.cabs.keys())
 
     if recipes_to_document or cabs_to_document:


### PR DESCRIPTION
@landmanbester would like your input on this especially, as it tweaks the logic of aliases.

The major change is that aliases for which a value is set inside a step definition (or by the cab default) now propagate up to recipe-level defaults. And they are no longer shown as "Hidden" by ``stimela doc``.

