### PR TITLE
make Py11 compliant

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stimela"
-version = "2.0"
+version = "2.0.1"
 description = "Framework for system agnostic pipelines for (not just) radio interferometry"
 authors = ["Sphesihle Makhathini <sphemakh@gmail.com>", "Oleg Smirnov and RATT <osmirnov@gmail.com>"]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<=3.12"
+python = ">=3.8,<3.13"
 munch = "^2.5.0"
 omegaconf = "^2.1"
 importlib_metadata = { version = "4.13.0", python = "3.7" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8,<=3.12"
 munch = "^2.5.0"
 omegaconf = "^2.1"
 importlib_metadata = { version = "4.13.0", python = "3.7" }

--- a/scabha/basetypes.py
+++ b/scabha/basetypes.py
@@ -24,6 +24,9 @@ def ListDefault(*args):
 def DictDefault(**kw):
     return field(default_factory=lambda:dict(**kw))
 
+def EmptyClassDefault(obj):
+    return field(default_factory=obj) 
+
 
 @dataclass
 class Unresolved(object):

--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -1,9 +1,9 @@
 import dataclasses
-import re, importlib, sys
+import re, importlib
 from collections import OrderedDict
-from enum import Enum, IntEnum
-from dataclasses import dataclass, field
-from omegaconf import MISSING, ListConfig, DictConfig, OmegaConf
+from enum import IntEnum
+from dataclasses import dataclass
+from omegaconf import ListConfig, DictConfig, OmegaConf
 
 import rich.box
 import rich.markup
@@ -13,7 +13,6 @@ from rich.markdown import Markdown
 from .exceptions import ParameterValidationError, DefinitionError, SchemaError, AssignmentError
 from .validate import validate_parameters, Unresolved
 from .substitutions import SubstitutionNS
-from .basetypes import EmptyDictDefault, EmptyListDefault, UNSET, is_file_list_type, is_file_type
 
 # need * imports from both to make eval(self.dtype, globals()) work
 from typing import *
@@ -147,7 +146,7 @@ class Parameter(object):
     nom_de_guerre: Optional[str] = None
 
     # policies object, specifying a non-default way to handle this parameter
-    policies: ParameterPolicies = field(default_factory=ParameterPolicies)
+    policies: ParameterPolicies = EmptyClassDefault(ParameterPolicies)
 
     # Parameter category, purely cosmetic, used for generating help and debug messages.
     # Assigned automatically if None, but a schema may explicitly mark parameters as e.g.
@@ -275,8 +274,8 @@ class Cargo(object):
                         value = value.strip()
                         default = default.strip()
                         if (default.startswith('"') and default.endswith('"')) or \
-                           (default.startswith("'") and default.endswith("'")): 
-                           default = default[1:-1]
+                        (default.startswith("'") and default.endswith("'")): 
+                            default = default[1:-1]
                         schema['default'] = default
                     # does value end with "*"? Mark as required
                     elif value.endswith("*"):
@@ -410,7 +409,7 @@ class Cargo(object):
                 if name in params and name not in self._implicit_params and params[name] != schema.implicit:
                     raise ParameterValidationError(f"implicit parameter {name} was supplied explicitly")
                 if name in self.defaults:
-                   raise SchemaError(f"implicit parameter {name} also has a default value")
+                    raise SchemaError(f"implicit parameter {name} also has a default value")
                 params[name] = schema.implicit
                 self._implicit_params.add(name)
                 if current:
@@ -434,9 +433,9 @@ class Cargo(object):
             schema.get_category()
 
         params = validate_parameters(params, self.inputs_outputs, defaults=self.defaults, subst=subst, fqname=self.fqname,
-                                          check_unknowns=True, check_required=False, 
-                                          check_inputs_exist=False, check_outputs_exist=False,
-                                          create_dirs=False, ignore_subst_errors=True)
+                                        check_unknowns=True, check_required=False, 
+                                        check_inputs_exist=False, check_outputs_exist=False,
+                                        create_dirs=False, ignore_subst_errors=True)
 
         return params
 
@@ -517,8 +516,8 @@ class Cargo(object):
                     schema.info and info.append(rich.markup.escape(schema.info))
                     attrs and info.append(f"[dim]\[{rich.markup.escape(', '.join(attrs))}][/dim]")
                     table.add_row(f"[bold]{name}[/bold]",
-                                  f"[dim]{rich.markup.escape(str(schema.dtype))}[/dim]",
-                                  " ".join(info))
+                                f"[dim]{rich.markup.escape(str(schema.dtype))}[/dim]",
+                                " ".join(info))
 
     def assign_value(self, key: str, value: Any, override: bool = False):
         """assigns a parameter value to the cargo. 

--- a/stimela/backends/__init__.py
+++ b/stimela/backends/__init__.py
@@ -1,11 +1,11 @@
 import logging
 from dataclasses import dataclass
-from typing import Union, Dict, Any, List, Optional
+from typing import Dict, Any, Optional
 from enum import Enum
 from omegaconf import ListConfig, OmegaConf
 from stimela.exceptions import BackendSpecificationError, BackendError
 from stimela.stimelogging import log_exception
-from scabha.basetypes import EmptyDictDefault
+from scabha.basetypes import EmptyDictDefault, EmptyClassDefault
 
 from .singularity import SingularityBackendOptions
 from .kube import KubeBackendOptions
@@ -49,17 +49,17 @@ class StimelaBackendOptions(object):
     
     select: Any = "singularity,native"   # should be Union[str, List[str]], but OmegaConf doesn't support it, so handle in __post_init__ for now
     
-    singularity: Optional[SingularityBackendOptions] = None
-    kube: Optional[KubeBackendOptions] = None
-    native: Optional[NativeBackendOptions] = None 
+    singularity: Optional[SingularityBackendOptions] = EmptyClassDefault(SingularityBackendOptions)
+    kube: Optional[KubeBackendOptions] = EmptyClassDefault(KubeBackendOptions)
+    native: Optional[NativeBackendOptions] = EmptyClassDefault(NativeBackendOptions)
     docker: Optional[Dict] = None  # placeholder for future impl
-    slurm: Optional[SlurmOptions] = None   
+    slurm: Optional[SlurmOptions] = EmptyClassDefault(SlurmOptions)
 
     ## Resource limits applied during run -- see resource module
     rlimits: Dict[str, Any] = EmptyDictDefault()
 
     verbose: int = 0  # be verbose about backend selections. Higher levels mean more verbosity
-
+    
     def __post_init__(self):
         # resolve "select" field
         if type(self.select) is str:

--- a/stimela/backends/flavours/casa.py
+++ b/stimela/backends/flavours/casa.py
@@ -65,22 +65,12 @@ class CasaTaskFlavour(_CallableFlavour):
             command = f"{virtual_env}/bin/{command}"
 
         self.command_name = command
-        # convert inputs into a JSON string
-        pass_params = cab.filter_input_params(params)
-        params_string = json.dumps(pass_params)
-
-        # unicode instance only exists in python2, python3 bytes
-        code = f"""
-import json
-from io import StringIO
-
-# cast to string/bytes
-stdr = StringIO('''{params_string}''').read()
-kw = json.loads(stdr.encode('ascii', errors='ignore'))
-
-{command}(**kw)
-
-"""
+        pass_params = dict(cab.filter_input_params(params))
+        
+        # parse the params direcly as python dictionary
+        # no need to string conversion between strings/bytes/unicode
+        # this works for both python 2.7 and 3.x
+        code = f"{command}(**{pass_params})"
 
         args =  casa.strip().split() + list(casa_opts) + ["-c", code]
         return args

--- a/stimela/backends/flavours/casa.py
+++ b/stimela/backends/flavours/casa.py
@@ -73,7 +73,7 @@ class CasaTaskFlavour(_CallableFlavour):
         self.script = tempfile.NamedTemporaryFile(suffix=".py", mode="wt")
         self.script.write(f"""
 import sys, json
-kw = json.loads(sys.argv[-1])
+kw = json.loads('{params_string}')
 
 try:
     utype = unicode
@@ -93,8 +93,9 @@ kw = {{key: stringify(value) for key, value in kw.items()}}
 {command}(**kw)
 
 """)
+        self.script.flush()
 
-        args =  casa.strip().split() + list(casa_opts) + ["-c", self.script.name, params_string]
+        args =  casa.strip().split() + list(casa_opts) + ["-c", self.script.name]
         return args
     
     def __del__(self):

--- a/stimela/backends/flavours/casa.py
+++ b/stimela/backends/flavours/casa.py
@@ -75,7 +75,7 @@ import json
 from io import StringIO
 
 # cast to string/bytes
-stdr = StringIO('{params_string}').read()
+stdr = StringIO('''{params_string}''').read()
 kw = json.loads(stdr.encode('ascii', errors='ignore'))
 
 {command}(**kw)

--- a/stimela/backends/flavours/casa.py
+++ b/stimela/backends/flavours/casa.py
@@ -79,6 +79,7 @@ try:
 except NameError:
     utype = bytes
 
+
 kw = dict()
 
 for key, val in kwin.items():
@@ -86,7 +87,10 @@ for key, val in kwin.items():
     if isinstance(val, (utype, str)):
         x = str(val)
     elif isinstance(val, list):
-        x = [stringify(y) for y in val]
+        try:
+            x = list(map(lambda a: str(a) if isinstance(a, (unicode, str)) else a, val))
+        except NameError:
+            x = list(map(lambda a: str(a) if isinstance(a, (bytes, str)) else a, val))
     else:
         x = val
         
@@ -98,4 +102,6 @@ for key, val in kwin.items():
 
         args =  casa.strip().split() + list(casa_opts) + ["-c", code]
         return args
+    
+
 

--- a/stimela/backends/flavours/casa.py
+++ b/stimela/backends/flavours/casa.py
@@ -71,30 +71,12 @@ class CasaTaskFlavour(_CallableFlavour):
 
         # unicode instance only exists in python2, python3 bytes
         code = f"""
-import sys, json
-kwin = json.loads('{params_string}')
+import json
+from io import StringIO
 
-try:
-    utype = unicode
-except NameError:
-    utype = bytes
-
-
-kw = dict()
-
-for key, val in kwin.items():
-    # stringify in a loop to avoid isue #300
-    if isinstance(val, (utype, str)):
-        x = str(val)
-    elif isinstance(val, list):
-        try:
-            x = list(map(lambda a: str(a) if isinstance(a, (unicode, str)) else a, val))
-        except NameError:
-            x = list(map(lambda a: str(a) if isinstance(a, (bytes, str)) else a, val))
-    else:
-        x = val
-        
-    kw[key] = x
+# cast to string/bytes
+stdr = StringIO('{params_string}').read()
+kw = json.loads(stdr.encode('ascii', errors='ignore'))
 
 {command}(**kw)
 

--- a/stimela/backends/kube/__init__.py
+++ b/stimela/backends/kube/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Any, Callable
+from typing import Dict, List, Optional, Any
 from enum import Enum
 from omegaconf import OmegaConf
 from dataclasses import dataclass
@@ -14,14 +14,15 @@ import grp
 import os
 
 import stimela
-from scabha.basetypes import EmptyDictDefault, DictDefault, EmptyListDefault, ListDefault
+from scabha.basetypes import ( EmptyDictDefault, DictDefault, EmptyListDefault, 
+                            ListDefault, EmptyClassDefault)
 from stimela.exceptions import BackendError
 
 session_id = secrets.token_hex(8)
 session_user = getpass.getuser()
 
 resource_labels = dict(stimela_user=session_user,
-                       stimela_session_id=session_id)
+                    stimela_session_id=session_id)
 
 try:
     import kubernetes
@@ -59,8 +60,8 @@ class KubePodSpec(object):
     # selects a specific pod type from a KubeBackendOptions.predefined_pod_specs
     type:           Optional[str] = None
     # memory limit/requirement
-    memory:         Optional[PodLimits] = None
-    cpu:            Optional[PodLimits] = None
+    memory:         Optional[PodLimits] = EmptyClassDefault(PodLimits)
+    cpu:            Optional[PodLimits] = EmptyClassDefault(PodLimits)
     # arbitrary additional structure copied into the pod spec
     custom_pod_spec:  Dict[str, Any] = EmptyDictDefault()
 
@@ -84,8 +85,8 @@ class KubeBackendOptions(object):
             report_pvcs: bool = True                  # report any transient PVCs
             cleanup_pvcs: bool = True                 # cleanup any transient PVCs
 
-        on_exit:    ExitOptions = ExitOptions()         # startup behaviour options
-        on_startup: StartupOptions = StartupOptions()   # cleanup behaviour options
+        on_exit:    ExitOptions = EmptyClassDefault(ExitOptions)         # startup behaviour options
+        on_startup: StartupOptions = EmptyClassDefault(StartupOptions)   # cleanup behaviour options
 
     @dataclass 
     class Volume(object):
@@ -140,8 +141,8 @@ class KubeBackendOptions(object):
         num_workers: int = 1
         threads_per_worker: int = 1
         memory_limit: Optional[str] = None
-        worker_pod: KubePodSpec = KubePodSpec()
-        scheduler_pod: KubePodSpec = KubePodSpec()
+        worker_pod: KubePodSpec = EmptyClassDefault(KubePodSpec)
+        scheduler_pod: KubePodSpec = EmptyClassDefault(KubePodSpec)
         forward_dashboard_port: int = 8787          # set to non-0 to forward the http dashboard to this local port
 
     @dataclass
@@ -157,15 +158,15 @@ class KubeBackendOptions(object):
         mkdir: bool = False         # create dir, if it is missing
 
 
-    enable:         bool = True
+    enable: bool = True
 
     # infrastructure settings are global and can't be changed per cab or per step
-    infrastructure: Infrastructure = Infrastructure()
+    infrastructure: Infrastructure = EmptyClassDefault(Infrastructure)
 
     context:        Optional[str] = None   # k8s context -- use default if not given -- can't change
     namespace:      Optional[str] = None   # k8s namespace
     
-    dask_cluster:   Optional[DaskCluster] = None  # if set, a DaskJob will be created
+    dask_cluster:   Optional[DaskCluster] = EmptyClassDefault(DaskCluster)  # if set, a DaskJob will be created
     service_account: str = "compute-runner"
     kubectl_path:   str = "kubectl"
 
@@ -198,9 +199,10 @@ class KubeBackendOptions(object):
         event_colors:  Dict[str, str] = DictDefault(
                                 warning="blue", error="yellow", default="grey50")
     
-    debug: DebugOptions = DebugOptions()                            
+    debug: DebugOptions = EmptyClassDefault(DebugOptions)
 
-    job_pod:        KubePodSpec = KubePodSpec()
+
+    job_pod: KubePodSpec = EmptyClassDefault(KubePodSpec)
     
     capture_logs_style: Optional[str] = "blue"
 
@@ -216,7 +218,7 @@ class KubeBackendOptions(object):
         home_ramdisk:   bool = True              # home dir mounted as RAM disk, else local disk
         inject_nss:     bool = True              # inject user info for NSS_WRAPPER
 
-    user: UserInfo = UserInfo()
+    user: UserInfo = EmptyClassDefault(UserInfo)
     
     # user-defined set of pod types -- each is a pod spec structure keyed by pod_type
     predefined_pod_specs: Dict[str, Dict[str, Any]] = EmptyDictDefault()

--- a/stimela/backends/kube/infrastructure.py
+++ b/stimela/backends/kube/infrastructure.py
@@ -2,13 +2,11 @@ import logging
 import atexit
 import json
 import time
-import rich
 from typing import Optional, Dict, List
 
 from stimela.backends import StimelaBackendOptions
-from stimela.stimelogging import log_exception, declare_chapter
+from stimela.stimelogging import log_exception
 from stimela.task_stats import update_process_status
-from scabha.basetypes import EmptyListDefault
 
 from stimela.exceptions import BackendError
 from . import session_id, session_user, resource_labels, run_kube, KubeBackendOptions, get_kube_api, get_context_namespace
@@ -104,7 +102,7 @@ def init(backend: StimelaBackendOptions, log: logging.Logger, cleanup: bool = Fa
 
     # cleanup transient PVCs
     transient_pvcs = {name: pvc for name, pvc in active_pvcs.items() 
-                      if pvc.metadata.labels and 'stimela_transient_pvc' in pvc.metadata.labels}
+                        if pvc.metadata.labels and 'stimela_transient_pvc' in pvc.metadata.labels}
     
     if transient_pvcs:
         if cleanup or kube.infrastructure.on_startup.cleanup_pvcs:

--- a/stimela/backends/kube/kube_utils.py
+++ b/stimela/backends/kube/kube_utils.py
@@ -2,7 +2,6 @@ import logging
 from typing import Dict, Any
 import re
 from datetime import datetime
-import rich
 from rich.markup import escape
 from requests import ConnectionError
 from urllib3.exceptions import HTTPError
@@ -12,7 +11,7 @@ from omegaconf import OmegaConf
 from stimela.exceptions import StimelaCabRuntimeError
 
 from kubernetes.client.rest import ApiException
-from . import get_kube_api, KubeBackendOptions, session_id
+from . import get_kube_api, KubeBackendOptions
 
 k8s_cpu_units = {
     "": 1,

--- a/stimela/backends/native/__init__.py
+++ b/stimela/backends/native/__init__.py
@@ -3,6 +3,9 @@ from typing import Optional
 import logging
 import stimela
 
+# add these as module attributes
+from .run_native import run, build_command_line, update_rlimits
+
 def is_available(opts = None):
     return True
 
@@ -12,12 +15,12 @@ def get_status():
 def is_remote():
     return False
 
-from .run_native import run, build_command_line, update_rlimits
 
 @dataclass
 class NativeBackendOptions(object):
     enable: bool = True
     virtual_env: Optional[str] = None
+    
 
 def init(backend: 'stimela.backend.StimelaBackendOptions', log: logging.Logger):
     pass

--- a/stimela/backends/native/run_native.py
+++ b/stimela/backends/native/run_native.py
@@ -1,6 +1,6 @@
 import logging, datetime, resource, os.path
 
-from typing import Dict, Optional, Any, List, Callable
+from typing import Dict, Optional, Any
 
 import stimela
 import stimela.kitchen

--- a/stimela/backends/runner.py
+++ b/stimela/backends/runner.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Any, Callable, List
+from typing import Dict, Optional, Any, List
 from dataclasses import dataclass
 from omegaconf import OmegaConf
 import stimela
@@ -32,11 +32,11 @@ class BackendRunner(object):
         
     def build(self, cab: 'stimela.kitchen.cab.Cab', log: logging.Logger, rebuild=False):
         if not hasattr(self.backend, 'build'):
-           log.warning(f"the {self.backend_name} backend does support or require image builds")
+            log.warning(f"the {self.backend_name} backend does support or require image builds")
         else:
             return self.backend.build(cab, backend=self.opts, log=log, rebuild=rebuild,
                                 wrapper=self.wrapper)
-
+    
 
 def validate_backend_settings(backend_opts: Dict[str, Any], log: logging.Logger) -> BackendRunner:
     """Checks that backend settings refer to a valid backend
@@ -76,6 +76,5 @@ def validate_backend_settings(backend_opts: Dict[str, Any], log: logging.Logger)
         wrapper = EmptyBackendWrapper()
 
     return BackendRunner(opts=backend_opts, is_remote=is_remote, is_remote_fs=is_remote_fs, 
-                          backend=backend, backend_name=backend_name,
-                          wrapper=wrapper)
-
+                        backend=backend, backend_name=backend_name,
+                        wrapper=wrapper)

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -6,14 +6,11 @@ import stimela
 from shutil import which
 from dataclasses import dataclass
 from omegaconf import OmegaConf
-from typing import Dict, List, Any, Optional, Callable
-from contextlib import ExitStack
+from typing import Dict, Any, Optional
 from scabha.basetypes import EmptyDictDefault
 import datetime
 from stimela.utils.xrun_asyncio import xrun
-
 from stimela.exceptions import BackendError
-
 from . import native
 
 ReadWriteMode = Enum("ReadWriteMode", "ro rw", module=__name__)
@@ -36,6 +33,7 @@ class SingularityBackendOptions(object):
     #     mount: str
 
     # tmp_dirs: List[EmptyVolume] = EmptyListDefault()
+    
 
 SingularityBackendSchema = OmegaConf.structured(SingularityBackendOptions)
 
@@ -43,6 +41,7 @@ STATUS = VERSION = BINARY = None
 
 # images rebuilt in this run
 _rebuilt_images = set()
+
 
 def is_available(opts: Optional[SingularityBackendOptions] = None):
     global STATUS, VERSION, BINARY
@@ -104,8 +103,8 @@ def get_image_info(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.Sti
 
 
 def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBackendOptions', log: logging.Logger,
-          wrapper: Optional['stimela.backend.runner.BackendWrapper']=None,
-          build=True, rebuild=False):
+            wrapper: Optional['stimela.backend.runner.BackendWrapper']=None,
+            build=True, rebuild=False):
     """Builds image for cab, if necessary.
 
     build: if True, build missing images regardless of backend settings

--- a/stimela/backends/slurm.py
+++ b/stimela/backends/slurm.py
@@ -1,17 +1,10 @@
-import subprocess
 import os
-import re
 import logging
-from stimela import utils
-import stimela
 from shutil import which
-from dataclasses import dataclass, make_dataclass
+from dataclasses import dataclass
 from omegaconf import OmegaConf
-from typing import Dict, List, Any, Optional, Tuple
-from contextlib import ExitStack
-from scabha.basetypes import EmptyListDefault, EmptyDictDefault, ListDefault
-import datetime
-from stimela.utils.xrun_asyncio import xrun
+from typing import Dict, List, Any, Optional
+from scabha.basetypes import EmptyDictDefault
 
 from stimela.exceptions import BackendError
 
@@ -31,6 +24,7 @@ class SlurmOptions(object):
     # required_mem_opts: Optional[List[str]] = ListDefault("mem", "mem-per-cpu", "mem-per-gpu")
     # # this will be applied if the required above are missing
     # default_mem_opt: str = "8GB"
+    
 
     def get_executable(self):
         global _default_srun_path
@@ -75,7 +69,4 @@ class SlurmOptions(object):
         #     if not set(self.srun_opts.keys()).intersection(self.required_mem_opts):
         #         self.srun_opts['mem'] = self.default_mem_opt
 
-
-
 SlurmOptionsSchema = OmegaConf.structured(SlurmOptions)
-

--- a/stimela/config.py
+++ b/stimela/config.py
@@ -1,9 +1,8 @@
 import importlib
-import os, os.path, time, sys, platform, traceback
-from typing import Any, List, Dict, Optional, Union
-from enum import Enum
+import os, os.path, time, platform, traceback
+from typing import Any, List, Dict, Optional
 from dataclasses import dataclass, field
-from omegaconf.omegaconf import MISSING, OmegaConf
+from omegaconf.omegaconf import OmegaConf
 from omegaconf.errors import OmegaConfBaseException
 from collections import OrderedDict
 
@@ -13,7 +12,7 @@ from stimela.exceptions import *
 from stimela import log_exception
 
 from scabha import configuratt
-from scabha.cargo import ListOrString, EmptyDictDefault, EmptyListDefault
+from scabha.basetypes import EmptyDictDefault, EmptyListDefault, EmptyClassDefault
 from stimela.backends import StimelaBackendOptions
 
 @dataclass 
@@ -21,18 +20,16 @@ class StimelaLogConfig(object):
     enable: bool = True                          
     name: str = "log-{info.fqname}"          # Default name for log file. info dict and {config.x.y} is substituted.
     ext: str = ".txt"                        # Default extension for log file.
- 
     dir: str = "."                               # Default directory for log files
 
     symlink: Optional[str] = None                # Will make named symlink to the log directory. A useful pattern is e.g. dir="logs-{config.run.datetime}", symlink="logs",
-                                                 # then each run has its own log dir, and "logs" always points to the latest one
+                                            # then each run has its own log dir, and "logs" always points to the latest one
 
     # how deep to nest individual log files. 0 means one log per recipe, 1 means one per step, 2 per each substep, etc. 
     nest: int = 999                             
     
     level: str = "INFO"                          # level at which we log
-
-
+    
 
 ## overall Stimela config schema
 
@@ -43,17 +40,18 @@ import stimela.backends
 class StimelaProfilingOptions(object):
     print_depth: int = 9999
     unroll_loops: bool = False
-
+    
 @dataclass
 class StimelaOptions(object):
-    backend: StimelaBackendOptions = StimelaBackendOptions()
-    log: StimelaLogConfig = StimelaLogConfig()
+    backend: StimelaBackendOptions = EmptyClassDefault(StimelaBackendOptions)
+    log: StimelaLogConfig = EmptyClassDefault(StimelaLogConfig)
     ## list of paths to search with _include
     include: List[str] = EmptyListDefault()
     ## Miscellaneous runtime options (runtime.casa, etc.)     
     runtime: Dict[str, Any] = EmptyDictDefault()    
     ## Profiling options
-    profile: StimelaProfilingOptions = StimelaProfilingOptions()
+    profile: StimelaProfilingOptions = EmptyClassDefault(StimelaProfilingOptions)
+    
 
 
 def DefaultDirs():
@@ -160,15 +158,17 @@ def load_config(extra_configs: List[str], extra_dotlist: List[str] = [], include
         steps: Dict[str, Any] = EmptyDictDefault()
         misc: Dict[str, Any] = EmptyDictDefault()
         wisdom: Dict[str, Any] = EmptyDictDefault()
+        
 
     @dataclass 
     class StimelaConfig:
         images: Dict[str, ImageInfo] = EmptyDictDefault()
-        lib: StimelaLibrary = StimelaLibrary()
+        lib: StimelaLibrary = EmptyClassDefault(StimelaLibrary)
         cabs: Dict[str, Cab] = EmptyDictDefault()
-        opts: StimelaOptions = StimelaOptions()
+        opts: StimelaOptions = EmptyClassDefault(StimelaOptions)
         vars: Dict[str, Any] = EmptyDictDefault()
         run:  Dict[str, Any] = EmptyDictDefault()
+        
 
     base_configs = lib_configs = cab_configs = []
 

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -1,7 +1,10 @@
-import os.path, re, stat, itertools, logging, yaml, shlex
+import os.path
+import itertools
+import yaml
+import shlex
 from typing import Any, List, Dict, Optional, Union
 from collections import OrderedDict
-from enum import Enum, IntEnum
+from enum import Enum
 from dataclasses import dataclass
 from omegaconf import MISSING, OmegaConf, DictConfig
 from omegaconf.errors import OmegaConfBaseException
@@ -10,9 +13,8 @@ import rich.markup
 from scabha.cargo import Parameter, Cargo, ListOrString, ParameterPolicies, ParameterCategory
 from stimela.exceptions import CabValidationError, StimelaCabRuntimeError, StimelaBaseImageError
 from scabha.exceptions import SchemaError
-from scabha.basetypes import EmptyDictDefault, EmptyListDefault
+from scabha.basetypes import EmptyDictDefault, EmptyListDefault, EmptyClassDefault
 from stimela.backends import flavours, StimelaBackendSchema
-import stimela
 from . import wranglers
 from scabha.substitutions import substitutions_from
 
@@ -103,10 +105,10 @@ class Cab(Cargo):
     parameter_passing: ParameterPassingMechanism = ParameterPassingMechanism.args
 
     # cab management and cleanup definitions
-    management: CabManagement = CabManagement()
+    management: CabManagement = EmptyClassDefault(CabManagement)
 
     # default parameter conversion policies
-    policies: ParameterPolicies = ParameterPolicies()
+    policies: ParameterPolicies = EmptyClassDefault(ParameterPolicies)
 
     def __post_init__ (self):
         Cargo.__post_init__(self)
@@ -175,9 +177,9 @@ class Cab(Cargo):
             return default
 
     def build_command_line(self, params: Dict[str, Any], 
-                           subst: Optional[Dict[str, Any]] = None, 
-                           virtual_env: Optional[str] = None,
-                           check_executable: bool = True):
+                        subst: Optional[Dict[str, Any]] = None, 
+                        virtual_env: Optional[str] = None,
+                        check_executable: bool = True):
         
         try:
             with substitutions_from(subst, raise_errors=True) as context:
@@ -466,6 +468,5 @@ CabSchema = None
 def get_cab_schema():
     global CabSchema
     if CabSchema is None:
-        import stimela.config
         CabSchema = OmegaConf.structured(Cab)
     return CabSchema


### PR DESCRIPTION
- Add `basetypes.EmptyClassDefault()` method because `dataclasses` in python 3.11 cannot have mutable (classes in this case) as default values. Updated all the class defaults I could fine.  It may be worth considering a 
```python
def __default__(self): 
    return dataclass.field(default_factory=self)
```
 method to our dataclasses then using ` foo: Bar = Bar.__default__()` when setting defaults.

- Save CASA code in a `tempfile` instead of parsing a multi-line code string; this did not work for me. 