### PR TITLE
Fix for bad shlex in venv activation

### DIFF
--- a/stimela/backends/flavours/binary.py
+++ b/stimela/backends/flavours/binary.py
@@ -26,7 +26,8 @@ class BinaryFlavour(_BaseFlavour):
 
         # prepend virtual env invocation, if asked
         if virtual_env:
-            args = ["/bin/bash", "--rcfile", f"{virtual_env}/bin/activate", "-c", shlex.quote(" ".join(shlex.quote(arg) for arg in args))]
+            venv_args = f". {virtual_env}/bin/activate && "
+            args = ["/bin/bash", "-c", venv_args + " ".join(shlex.quote(arg) for arg in args)]
 
         return args
     


### PR DESCRIPTION
This is a minor fix which probably should reach master. Fixes a bug which results in the entire command being interpreted as a single path.