### PR TITLE
tiny fix for #339

### DIFF
--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -319,7 +319,7 @@ def construct_parser():
         (Literal("&"), 2, opAssoc.LEFT, BinaryHandler.pa),
         (Literal("^"), 2, opAssoc.LEFT, BinaryHandler.pa),
         (Literal("|"), 2, opAssoc.LEFT, BinaryHandler.pa),
-        (reduce(operator.or_, map(Literal, ("==", "!=", ">", "<", ">=", "<="))), 2, opAssoc.LEFT, BinaryHandler.pa),
+        (reduce(operator.or_, map(Literal, ("==", "!=", ">=", "<=", ">", "<"))), 2, opAssoc.LEFT, BinaryHandler.pa),
         (CaselessKeyword("in")|CaselessKeyword("not in"), 2, opAssoc.LEFT, BinaryHandler.pa),
         (CaselessKeyword("not"), 1, opAssoc.RIGHT, UnaryHandler.pa),
         (CaselessKeyword("and")|CaselessKeyword("or"), 2, opAssoc.LEFT, BinaryHandler.pa),

--- a/tests/scabha_tests/test_parsing.py
+++ b/tests/scabha_tests/test_parsing.py
@@ -12,6 +12,7 @@ def test_parser():
             "a.b + b.c - c.d",
             "a.b + b.c * c.d",
             "a.b + -b.c",
+            "a.b <= 0",
             "a.b", 
             "IFSET(a.b)",
                 ]:


### PR DESCRIPTION
Turns out order is important for pyparser... "<" must come after "<=" to prevent a partial match leading to parser breakage.