### PR TITLE
Fix the regular expression escapes for more recent python versions. 

### DIFF
--- a/scabha/basetypes.py
+++ b/scabha/basetypes.py
@@ -70,7 +70,7 @@ class URI(str):
 
         If expand_user is True, ~ in (file-protocol) paths will be expanded.
         """
-        match = re.fullmatch("((\w+)://)(.*)", value)
+        match = re.fullmatch(r'((\w+)://)(.*)', value)
         if not match:
             protocol, path, remote = "file", value, False
         else:

--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -524,7 +524,7 @@ class Cargo(object):
                         attrs.append(f"choices: {', '.join(schema.choices)}")
                     info = []
                     schema.info and info.append(rich.markup.escape(schema.info))
-                    attrs and info.append(f"[dim]\[{rich.markup.escape(', '.join(attrs))}][/dim]")
+                    attrs and info.append(f"[dim]\\[{rich.markup.escape(', '.join(attrs))}][/dim]")
                     table.add_row(f"[bold]{name}[/bold]",
                                 f"[dim]{rich.markup.escape(str(schema.dtype))}[/dim]",
                                 " ".join(info))

--- a/scabha/configuratt/resolvers.py
+++ b/scabha/configuratt/resolvers.py
@@ -218,7 +218,7 @@ def resolve_config_refs(conf, pathname: str, location: str, name: str, includes:
                         if not incl:
                             raise ConfigurattError(f"{errloc}: empty {keyword} specifier")
                         # check for [flags] at end of specifier
-                        match = re.match("^(.*)\[(.*)\]$", incl)
+                        match = re.match(r'^(.*)\[(.*)\]$', incl)
                         if match:
                             incl = match.group(1)
                             flags = set([x.strip().lower() for x in match.group(2).split(",")])

--- a/stimela/backends/kube/__init__.py
+++ b/stimela/backends/kube/__init__.py
@@ -195,7 +195,7 @@ class KubeBackendOptions(object):
         # if >0, events will be collected and reported
         log_events:  bool = False
         # format string for reporting kubernetes events, this can include rich markup
-        event_format:  str = "=NOSUBST('\[k8s event type: {event.type}, reason: {event.reason}] {event.message}')"
+        event_format:  str = "=NOSUBST('\\[k8s event type: {event.type}, reason: {event.reason}] {event.message}')"
         event_colors:  Dict[str, str] = DictDefault(
                                 warning="blue", error="yellow", default="grey50")
     

--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -46,7 +46,7 @@ def resolve_recipe_file(filename: str):
 
     # check for (location)filename.yml or (location)/filename.yml style
     match1 = re.fullmatch("^\\((.+)\\)/?(.+)$", filename)
-    match2 = re.fullmatch("^([\w.]+)::(.+)$", filename)
+    match2 = re.fullmatch(r"^([\w.]+)::(.+)$", filename)
     if match1 or match2:
         modulename, fname = (match1 or match2).groups()
         try:
@@ -84,7 +84,7 @@ def load_recipe_files(filenames: List[str]):
     for filename in filenames:
         # check for (location)filename.yaml or (location)/filename.yaml style
         match1 = re.fullmatch("^\\((.+)\\)/?(.+)$", filename)
-        match2 = re.fullmatch("^([\w.]+)::(.+)$", filename)
+        match2 = re.fullmatch(r"^([\w.]+)::(.+)$", filename)
         if match1 or match2:
             modulename, filename = (match1 or match2).groups()
             try:

--- a/stimela/config.py
+++ b/stimela/config.py
@@ -272,7 +272,7 @@ def load_config(extra_configs: List[str], extra_dotlist: List[str] = [], include
         ncpu=psutil.cpu_count(logical=True),
         node=platform.node().split('.', 1)[0],
         hostname=platform.node(), 
-        env={key: value.replace('${', '\${') for key, value in os.environ.items()})
+        env={key: value.replace('${', r'\${') for key, value in os.environ.items()})
     runtime['ncpu-logical'] = psutil.cpu_count(logical=True)
     runtime['ncpu-physical'] = psutil.cpu_count(logical=False)
 

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -506,7 +506,7 @@ class Recipe(Cargo):
             alias_target = alias_target.replace("$", alias_name.rsplit('.', 1)[-1])
             step_spec, step_param_name = alias_target.split('.', 1)
             # treat label as a "(cabtype)" specifier?
-            if re.match('^\(.+\)$', step_spec):
+            if re.match(r'^\(.+\)$', step_spec):
                 steps = [(label, step) for label, step in self.steps.items() 
                         if (isinstance(step.cargo, Cab) and step.cab == step_spec[1:-1]) or
                             (isinstance(step.cargo, Recipe) and step.recipe == step_spec[1:-1])]

--- a/stimela/kitchen/wranglers.py
+++ b/stimela/kitchen/wranglers.py
@@ -204,7 +204,7 @@ class ParseOutput(_BaseWrangler):
         self.name = name or group
         if group in regex.groupindex:
             self.gid = group
-        elif re.fullmatch('\d+', group):
+        elif re.fullmatch(r'\d+', group):
             gid = int(group)
             if gid > regex.groups:
                 raise CabValidationError(f"wrangler action '{spec}' for '{regex.pattern}': {gid} is not a valid ()-group")


### PR DESCRIPTION

The following syntaxWarnings appear in python 3.12.

```
scabha/basetypes.py:73: SyntaxWarning: invalid escape sequence '\w'
  match = re.fullmatch("((\w+)://)(.*)", value)

stimela/config.py:275: SyntaxWarning: invalid escape sequence '\$'
  env={key: value.replace('${', '\${') for key, value in os.environ.items()})

scabha/configuratt/resolvers.py:221: SyntaxWarning: invalid escape sequence '\['
  match = re.match("^(.*)\[(.*)\]$", incl)

stimela/backends/kube/__init__.py:198: SyntaxWarning: invalid escape sequence '\['
  event_format:  str = "=NOSUBST('\[k8s event type: {event.type}, reason: {event.reason}] {event.message}')"

scabha/cargo.py:527: SyntaxWarning: invalid escape sequence '\['
  attrs and info.append(f"[dim]\[{rich.markup.escape(', '.join(attrs))}][/dim]")

stimela/kitchen/recipe.py:509: SyntaxWarning: invalid escape sequence '\('
  if re.match('^\(.+\)$', step_spec):

stimela/kitchen/wranglers.py:207: SyntaxWarning: invalid escape sequence '\d'
  elif re.fullmatch('\d+', group):

stimela/commands/run.py:49: SyntaxWarning: invalid escape sequence '\w'
  match2 = re.fullmatch("^([\w.]+)::(.+)$", filename)

stimela/commands/run.py:87: SyntaxWarning: invalid escape sequence '\w'
  match2 = re.fullmatch("^([\w.]+)::(.+)$", filename)
```

The strings should be raw strings eg, `"((\w+)://)(.*)"` should become  `r'((\w+)://)(.*)'`, otherwise the \w will be treated as an escaped unicode character. Alternatively replace \w with \\w.

See [here](https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d) for details.
