### PR TITLE
Fix regexp for later versions of python

### DIFF
--- a/scabha/configuratt/resolvers.py
+++ b/scabha/configuratt/resolvers.py
@@ -229,7 +229,7 @@ def resolve_config_refs(conf, pathname: str, location: str, name: str, includes:
                             warn = optional = False
 
                         # check for (location)filename.yaml or (location)/filename.yaml style
-                        match = re.match("^\\((.+)\\)/?(.+)$", incl)
+                        match = re.match(r"^\((.+)\)/?(.+)$", incl)
                         if match:
                             modulename, filename = match.groups()
                             if modulename.startswith("."):

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -208,7 +208,7 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]],
             elif dtype in ("MS", "File", "Directory"):
                 dtype = click.Path(exists=(io is schemas.inputs))
             else:
-                list_match = re.fullmatch("List\[(.*)\]", dtype)
+                list_match = re.fullmatch(r"List\[(.*)\]", dtype)
                 tuple_match = re.fullmatch("Tuple\[(.*)\]", dtype)
                 # List[x] type? Add validation callback to convert elements
                 if list_match:

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -209,7 +209,7 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]],
                 dtype = click.Path(exists=(io is schemas.inputs))
             else:
                 list_match = re.fullmatch(r"List\[(.*)\]", dtype)
-                tuple_match = re.fullmatch("Tuple\[(.*)\]", dtype)
+                tuple_match = re.fullmatch(r"Tuple\[(.*)\]", dtype)
                 # List[x] type? Add validation callback to convert elements
                 if list_match:
                     elem_type = _atomic_types.get(list_match.group(1).strip(), str)

--- a/stimela/backends/kube/kube_utils.py
+++ b/stimela/backends/kube/kube_utils.py
@@ -39,7 +39,7 @@ k8s_memory_units_in_bytes = {
 }
 
 def resolve_unit(quantity:str, units: Dict = k8s_memory_units_in_bytes):
-    match = re.fullmatch("^(\d+)(.*)$", quantity)
+    match = re.fullmatch(r"^(\d+)(.*)$", quantity)
     if not match or match.group(2) not in units:
         raise ApiException(f"invalid quantity '{quantity}'")
     return int(match.group(1))*units[match.group(2)]

--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -45,7 +45,7 @@ def resolve_recipe_file(filename: str):
         return None
 
     # check for (location)filename.yml or (location)/filename.yml style
-    match1 = re.fullmatch("^\\((.+)\\)/?(.+)$", filename)
+    match1 = re.fullmatch(r"^\((.+)\)/?(.+)$", filename)
     match2 = re.fullmatch(r"^([\w.]+)::(.+)$", filename)
     if match1 or match2:
         modulename, fname = (match1 or match2).groups()
@@ -83,7 +83,7 @@ def load_recipe_files(filenames: List[str]):
     full_deps = configuratt.ConfigDependencies()
     for filename in filenames:
         # check for (location)filename.yaml or (location)/filename.yaml style
-        match1 = re.fullmatch("^\\((.+)\\)/?(.+)$", filename)
+        match1 = re.fullmatch(r"^\((.+)\)/?(.+)$", filename)
         match2 = re.fullmatch(r"^([\w.]+)::(.+)$", filename)
         if match1 or match2:
             modulename, filename = (match1 or match2).groups()

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -142,7 +142,7 @@ class Cab(Cargo):
             self.name = self.command or self.image
 
         # split off first word of name to avoid non-alphanumeric characters
-        match = re.match("(\w+)", self.name)
+        match = re.match(r"(\w+)", self.name)
         if match:
             self.name = match.group(1) or self.flavour.kind
         else:

--- a/stimela/stimela.conf
+++ b/stimela/stimela.conf
@@ -5,11 +5,11 @@ images:
     default-python: 
         registry: quay.io/stimela2
         name: python-astro
-        version: cc0.1.2
+        version: cc0.1.3
     default-casa: 
         registry: quay.io/stimela2
         name: casa
-        version: cc0.1.2
+        version: cc0.1.3
 
 opts:
     runtime:


### PR DESCRIPTION
Just a few more fixes, solved by converting regexp strings to raw strings.