### PR TITLE
Clickify cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-numpy = "^1.20"
 munch = "^2.5.0"
 omegaconf = "^2.1"
 importlib_metadata = { version = "4.13.0", python = "3.7" }

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -3,7 +3,6 @@ import glob
 import os.path
 import fnmatch
 import pyparsing
-import numpy as np
 pyparsing.ParserElement.enable_packrat()
 from pyparsing import *
 from pyparsing import common
@@ -182,7 +181,7 @@ class FunctionHandler(ResultsHandler):
     
     def IS_NUM(self, evaluator, args):
         def is_num(x):
-            return np.isscalar(x) and (np.isreal(x) or np.isscalar(x)) 
+            return isinstance(x, (bool, int, float, complex)) 
         return self.evaluate_generic_callable(evaluator, "IS_NUM", is_num, args, min_args=1, max_args=1)
 
     def IF(self, evaluator, args):

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -176,8 +176,13 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]],
     package.
 
     Args:
-        schemas (str): The YAML filename for the parameter schema.
-        default_policies: Needs documentation.
+        schemas (str or Dict): Either the YAML filename from which the parameter schema is loaded,
+            containing inputs, outputs and an [optional] policies section,
+            or a DictConfig object containing inputs/outputs/policies.
+            See https://stimela.readthedocs.io/en/latest/reference/schema_ref.html
+        default_policies: default policies applied to the schema, overrides the policies section
+            if supplied. See ParameterPolicies in scabha/cargo.py, and
+            https://stimela.readthedocs.io/en/latest/reference/policies.html  
 
     Example:
     =======
@@ -195,9 +200,6 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]],
         outputs:
         {}
 
-        policies:
-            pass_missing_as_none: true
-
     The corresponding python code uses clickify_parameters as 
     a decorator:
         import click
@@ -208,12 +210,9 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]],
 
         @click.command()
         @clickify_parameters('hello/hello.yml')
-        def hello(**kw):
-            # Simple program that greets NAME for a total of COUNT times.
-            opts = OmegaConf.create(kw)
-
-            for x in range(opts.count):
-                click.echo(f"Hello {opts.name}!")
+        def hello(count: int = 1, name: Optional[str] = None):
+            for x in range(count):
+                click.echo(f"Hello {name}!")
     Returns:
         Nothing
     """

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -617,7 +617,7 @@ class Step:
                 level = logging.WARNING if self.skip else logging.ERROR
                 if not exc.logged:
                     if type(exc) is SubstitutionErrorList:
-                        self.log_exception(StepValidationError(f"unresolved {{}}-substitution(s) in inputs:", exc.nested), severity=severity)
+                        self.log_exception(StepValidationError(f"unresolved {{}}-substitution(s) in outputs:", exc.nested), severity=severity)
                         # for err in exc.errors:
                         #     self.log.log(level, f"  {err}")
                     else:

--- a/tests/scabha_tests/test_clickify.py
+++ b/tests/scabha_tests/test_clickify.py
@@ -6,7 +6,7 @@ import click
 
 @click.command()
 @clickify_parameters("test_clickify.yaml")
-def func(name: str, i: int, j: Optional[float] = None,
+def func(name: str, i: int, j: Optional[float] = 1,
          remainder: Optional[List[str]] = None, 
          k: float=2,
          tup: Optional[Tuple[int, str]] = None, 
@@ -14,7 +14,7 @@ def func(name: str, i: int, j: Optional[float] = None,
          files2: Optional[List[str]] = None,
          files3: Optional[List[str]] = None,
          output: str = None):
-    print(f"{name} {i} {j} {k} {tup}")
+    print(f"name:{name} i:{i} j:{j} k:{k} tup:{tup}")
     print(f"remainder: {remainder}")
     print(f"files1: {files1}")
     print(f"files2: {files2}")

--- a/tests/scabha_tests/test_clickify.py
+++ b/tests/scabha_tests/test_clickify.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+from scabha.schema_utils import clickify_parameters
+from typing import Tuple, List, Optional
+import sys
+import click
+
+@click.command()
+@clickify_parameters("test_clickify.yaml")
+def func(name: str, i: int, j: Optional[float] = None,
+         remainder: Optional[List[str]] = None, 
+         k: float=2,
+         tup: Optional[Tuple[int, str]] = None, 
+         files1: Optional[List[str]] = None,
+         files2: Optional[List[str]] = None,
+         files3: Optional[List[str]] = None,
+         output: str = None):
+    print(f"{name} {i} {j} {k} {tup}")
+    print(f"remainder: {remainder}")
+    print(f"files1: {files1}")
+    print(f"files2: {files2}")
+    print(f"files3: {files3}")
+    print(f"output: {output}")
+
+if __name__ == "__main__":
+    sys.exit(func())
+

--- a/tests/scabha_tests/test_clickify.py
+++ b/tests/scabha_tests/test_clickify.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
-from scabha.schema_utils import clickify_parameters
 from typing import Tuple, List, Optional
 import sys
+import os.path
 import click
+from scabha.schema_utils import clickify_parameters
+
+schema_file = os.path.join(os.path.dirname(__file__), "test_clickify.yaml")
 
 @click.command()
-@clickify_parameters("test_clickify.yaml")
+@clickify_parameters(schema_file)
 def func(name: str, i: int, j: Optional[float] = 1,
          remainder: Optional[List[str]] = None, 
          k: float=2,

--- a/tests/scabha_tests/test_clickify.yaml
+++ b/tests/scabha_tests/test_clickify.yaml
@@ -1,0 +1,42 @@
+inputs:
+  name: 
+    dtype: str
+    required: true
+    policies: 
+      positional: true
+  i: 
+    dtype: int 
+    required: true
+    policies: 
+      positional: true
+  remainder:
+    dtype: List[str]
+    policies: 
+      positional: true
+      repeat: list
+  j: 
+    dtype: float
+  k: 
+    dtype: float
+    default: 2
+  tup: 
+    dtype: Optional[Tuple[int, str]] 
+  files1: 
+    dtype: List[str]
+    policies: 
+      repeat: ' '
+  files2: 
+    dtype: List[File]
+    required: false
+    policies: 
+      repeat: repeat
+  files3: 
+    dtype: List[File]
+    required: false
+    policies: 
+      repeat: '[]'
+
+outputs:
+  output:
+    dtype: File
+    required: false


### PR DESCRIPTION
@landmanbester please check if this works with PFB.

I've removed the ``pass_missing_as_none`` logic from ``clickify_parameters()``, as upon closer investigation, this is what click now does always and anyways, except when dealing with some multiply-valued parameters (that is, Lists with a policy of repeat: repeat, in which case a missing parameter is passed as an empty tuple). I don't see any way to change this behaviour. The new code checks for UNSET defaults, and doesn't give click a default value for them, which results in a ``None`` being passed to the callable in the absence of the parameter. I think this behaviour is harmless and unlikely to trip us up, except when you have something perverted like

```python
def func(a: float=3):
  print(a)
```

with a schema that doesn't mention the default from the function signature:

```yaml
a:
  dtype: float
  required: false
```
...which results in ``func(a=None)`` when the command-line doesn't specify ``--a``. This is because neither stimela nor click knows anything about the signature actually, and has no choice but to trust what the schema says.

Note that ``pass_missing_as_none`` is still honoured by stimela itself when invoking a cab (i.e. is the difference between having nothing in ``**kw``, or having a ``None`` value in ``**kw``). Given your love for ``**kw``, I think this is what you expect, right?



