### PR TITLE
Fixes #377. Fixes #376.

### DIFF
--- a/docs/source/reference/backend_ref.rst
+++ b/docs/source/reference/backend_ref.rst
@@ -37,7 +37,7 @@ Native backend settings
 
 The native backend has only a couple of settings::
 
-    backends:
+    backend:
         native:
             enable: true
             virtual_env: ~/venvs/my_venv
@@ -51,7 +51,7 @@ Singularity backend settings
 
 The Singularity backend has the following settings::
 
-    backends:
+    backend:
         singularity:
             enable: true
             image_dir: ~/.singularity
@@ -74,7 +74,7 @@ Slurm wrapper settings
 
 Slurm is a wrapper, not a backend per se. It can be used in combination with the native and Singularity backends to schedule steps as Slurm jobs (using ``srun``). Enabling it can be as simple as setting ``enable`` to true::
 
-    backends:
+    backend:
         slurm:
             enable: false
             srun_path:              # optional path to srun executable

--- a/docs/source/reference/cabdefs.rst
+++ b/docs/source/reference/cabdefs.rst
@@ -173,9 +173,8 @@ An alternative way to specify flavours is to make ``flavour`` a sub-section, and
                 kind: casa-task
                 path: /usr/local/bin/casa
                 opts: [--nologger]
-                log_full_command: true
 
-The above tells Stimela to use a non-default CASA intepreter, and to pass it specific extra options on the command line. The ``log_full_command: true`` setting will cause the complete command line, including the encoded inputs (as opposed to just the command name) to be logged when the cab is invoked, which can be useful for debugging.
+The above tells Stimela to use a non-default CASA intepreter, and to pass it specific extra options on the command line. 
 
 Note that the CASA path and option settings can also be defined globally via :ref:`Stimela configuration <options>`.
 

--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -127,6 +127,8 @@ class Parameter(object):
 
     # if true, create parent directories of file-type outputs if needed
     mkdir: bool = True
+    # if true, create directory-type outputs themselves
+    mkdir_self: bool = False
 
     # if True, and parameter is a path, access to its parent directory is required
     access_parent_dir: bool = False

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -549,14 +549,17 @@ class Evaluator(object):
         # string? evaluate directly and return
         if type(obj) is str:
             try:
-                return self.evaluate(obj, sublocation=sublocation)
+                value = self.evaluate(obj, sublocation=sublocation)
+                if isinstance(value, Unresolved) and not self.allow_unresolved:
+                    raise SubstitutionError(f"{'.'.join(sublocation)}: unresolved substitution", [value])
+                return value
             except AttributeError as err:
-                if raise_substitution_errors:
-                    raise
+                if raise_substitution_errors or not self.allow_unresolved:
+                    raise SubstitutionError(f"{'.'.join(sublocation)}: substitution error", [err])
                 return Unresolved(errors=[err])
             except SubstitutionError as err:
-                if raise_substitution_errors:
-                    raise
+                if raise_substitution_errors or not self.allow_unresolved:
+                    raise SubstitutionError(f"{'.'.join(sublocation)}: substitution error", [err])
                 return Unresolved(errors=[err])
             
         # helper function

--- a/stimela/backends/flavours/__init__.py
+++ b/stimela/backends/flavours/__init__.py
@@ -14,9 +14,6 @@ class _BaseFlavour(object):
     A flavour class represents a particular kind of runnable task
     (binary, python callable, inline python code, etc.)
     """
-    # if true, full command line is logged, else just command name
-    log_full_command: bool = True
-
     def finalize(self, cab: "stimela.kitchen.cab.Cab"):
         """Finalizes flavour definition, given a cab"""
         self.command_name = cab.command.split()[0]
@@ -35,6 +32,11 @@ class _BaseFlavour(object):
             subst (Dict[str, Any]):  substitution namespace 
             virtual_env (Optional[str]): virtual environment to run in
             check_executable:        if True, cab may check for the executable to exist (but doesn't have to)
+
+        Returns:
+            Tuple[List, List]:       tuple of full_argument_list, abbreviated_argument_list
+                                     The full list is meant for execution, the abbreviated list is meant for
+                                     display and logging
         """
         pass
 

--- a/stimela/backends/flavours/binary.py
+++ b/stimela/backends/flavours/binary.py
@@ -29,7 +29,7 @@ class BinaryFlavour(_BaseFlavour):
             venv_args = f". {virtual_env}/bin/activate && "
             args = ["/bin/bash", "-c", venv_args + " ".join(shlex.quote(arg) for arg in args)]
 
-        return args
+        return args, args
     
     def get_image_name(self, cab: Cab, backend: 'stimela.backend.StimelaBackendOptions'):
         from stimela.backends import resolve_image_name

--- a/stimela/backends/flavours/casa.py
+++ b/stimela/backends/flavours/casa.py
@@ -79,8 +79,9 @@ class CasaTaskFlavour(_CallableFlavour):
         # this works for both python 2.7 and 3.x
         code = f"{command}(**{pass_params})"
 
-        args =  wrapper + casa.strip().split() + list(casa_opts) + ["-c", code]
-        return args
+        args =  wrapper + casa.strip().split() + list(casa_opts)
+        
+        return args + ["-c", code], args + ["-c", "..."]
     
 
 

--- a/stimela/backends/flavours/python_flavours.py
+++ b/stimela/backends/flavours/python_flavours.py
@@ -73,8 +73,6 @@ class PythonCallableFlavour(_CallableFlavour):
     interpreter_binary: str = "python"
     # Full command used to launch interpreter. {python} gets substituted for the interpreter path
     interpreter_command: str = "{python} -u"
-    # don't log full command by default, as that's full of code
-    log_full_command: bool = False
 
     def finalize(self, cab: Cab):
         super().finalize(cab)
@@ -142,8 +140,7 @@ _result = {py_function}(**_inputs)
         """
 
         args = get_python_interpreter_args(cab, subst, virtual_env=virtual_env)
-        args += ["-c", code, params_string]
-        return args
+        return args + ["-c", code, params_string], args + ["-c", "..."]
 
 
 @dataclass
@@ -165,8 +162,6 @@ class PythonCodeFlavour(_BaseFlavour):
     interpreter_binary: str = "python"
     # Full command used to launch interpreter. {python} gets substituted for the interpreter path
     interpreter_command: str = "{python} -u"
-    # don't log full command by default, as that's full of code
-    log_full_command: bool = False
 
     def finalize(self, cab: Cab):
         super().finalize(cab)
@@ -222,5 +217,4 @@ class PythonCodeFlavour(_BaseFlavour):
 
         # form up interpreter invocation
         args = get_python_interpreter_args(cab, subst, virtual_env=virtual_env)
-        args += ["-c", pre_command + command + post_command, params_arg]
-        return args
+        return args + ["-c", pre_command + command + post_command, params_arg], args + ["-c", "..."]

--- a/stimela/backends/kube/run_kube.py
+++ b/stimela/backends/kube/run_kube.py
@@ -44,8 +44,9 @@ def run(cab: Cab, params: Dict[str, Any], fqname: str,
 
     kube = backend.kube
 
-    args = cab.flavour.get_arguments(cab, params, subst, check_executable=False)
-    log.debug(f"command line is {args}")
+    args, log_args = cab.flavour.get_arguments(cab, params, subst, check_executable=False)
+
+    log.debug(f"command line is {' '.join(log_args)}")
 
     cabstat = cab.reset_status()
 

--- a/stimela/backends/native/run_native.py
+++ b/stimela/backends/native/run_native.py
@@ -68,9 +68,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
                 raise BackendSpecificationError(f"virtual environment {venv} doesn't exist")
             log.debug(f"virtual environment is {venv}")
 
-    args = build_command_line(cab, params, subst, virtual_env=venv)
-
-    log.debug(f"command line is {args}")
+    args, log_args = build_command_line(cab, params, subst, virtual_env=venv)
 
     cabstat = cab.reset_status()
 
@@ -85,13 +83,15 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
     # log.info(f"argument lengths are {[len(a) for a in args]}")
     
     if wrapper:
-        args = wrapper.wrap_run_command(args, fqname=fqname, log=log)
+        args, log_args = wrapper.wrap_run_command(args, log_args, fqname=fqname, log=log)
+        
+    log.debug(f"command line is {' '.join(log_args)}")
 
     retcode = xrun(args[0], args[1:], shell=False, log=log,
                 output_wrangler=cabstat.apply_wranglers,
                 return_errcode=True, command_name=command_name, 
                 gentle_ctrl_c=True,
-                log_command=True if cab.flavour.log_full_command else command_name, 
+                log_command=' '.join(log_args), 
                 log_result=False)
 
     # check if output marked it as a fail

--- a/stimela/backends/runner.py
+++ b/stimela/backends/runner.py
@@ -10,8 +10,8 @@ from . import get_backend
 
 
 class EmptyBackendWrapper(object):
-    def wrap_run_command(self, args: List[str], fqname: Optional[str]=None, log: Optional[logging.Logger]=None) -> List[str]:
-        return args
+    def wrap_run_command(self, args: List[str], log_args: List[str], fqname: Optional[str]=None, log: Optional[logging.Logger]=None) -> List[str]:
+        return args, log_args
 
     def wrap_build_command(self, args: List[str], fqname: Optional[str]=None, log: Optional[logging.Logger]=None) -> List[str]:
         return args

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -129,7 +129,7 @@ def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBacke
             raise BackendError(f"invalid singularity image directory {backend.singularity.image_dir}")
     else:
         try:
-            os.mkdir(backend.singularity.image_dir)
+            pathlib.Path(backend.singularity.image_dir).mkdir(parents=True)
         except OSError as exc:
             raise BackendError(f"failed to create singularity image directory {backend.singularity.image_dir}: {exc}")
 

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -97,7 +97,7 @@ def get_image_info(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.Sti
         simg_path = cab.image.path
         if not os.path.exists(simg_path):
             raise BackendError(f"image {simg_path} for cab '{cab.name}' doesn't exist")
-        return os.path.basename(simg_path), simg_path, False
+        return os.path.basename(simg_path), simg_path
 
     image_name = cab.flavour.get_image_name(cab, backend)
 

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -2,13 +2,15 @@ import subprocess
 import os
 import logging
 import pathlib
+from tempfile import TemporaryDirectory
+from contextlib import ExitStack
 from enum import Enum
 import stimela
 from shutil import which
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from omegaconf import OmegaConf
 from typing import Dict, Any, Optional, List
-from scabha.basetypes import EmptyDictDefault, EmptyListDefault, Unresolved
+from scabha.basetypes import EmptyDictDefault, EmptyListDefault
 import datetime
 from stimela.utils.xrun_asyncio import xrun
 from stimela.exceptions import BackendError
@@ -20,7 +22,7 @@ ReadWrite = Enum("BindMode", "ro rw", module=__name__)
 class SingularityBackendOptions(object):
     @dataclass
     class BindDir(object):
-        host: str                       # host path
+        host: Optional[str] = None      # host path, default uses label, or else "empty" for tmpdir
         target: Optional[str] = None    # container path: ==host by default
         mode: ReadWrite = "rw"
         mkdir: bool = False             # create host directory if it doesn't exist
@@ -34,7 +36,7 @@ class SingularityBackendOptions(object):
     remote_only: bool = False      # if True, won't look for singularity on local system -- useful in combination with slurm wrapper
 
     # optional extra bindings
-    bind_dirs: List[BindDir] = EmptyListDefault()
+    bind_dirs: Dict[str, BindDir] = EmptyDictDefault()
     env: Dict[str, str] = EmptyDictDefault()
     # @dataclass
     # class EmptyVolume(object):
@@ -277,103 +279,115 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
     # dict of container paths to host paths
     container_to_host_path = {}
 
-    # add extra binds
-    for bind in backend.singularity.bind_dirs:
-        if not bind.conditional:
-            log.info(f"skipping bind of {bind.host} based on false conditional")
-            continue
+    with ExitStack() as exit_stack: 
+        # add extra binds
+        for label, bind in backend.singularity.bind_dirs.items():
+            # a bit ugly, but converting back to container from an OmegaConf dict causes
+            # everything to be stringified
+            if bind.conditional in ("False", "None", "0"):
+                log.info(f"bind_dirs.{label}: skipping based on conditional=={bind.conditional}")
+                continue
 
-        # expand ~ in paths
-        src = os.path.expanduser(bind.host).rstrip("/")
-        dest = os.path.expanduser(bind.target or src).rstrip("/")
-        rw = bind.mode == ReadWrite.rw
-        
-        # resolve symlinks
-        if os.path.realpath(src) != src:
-            src = os.path.realpath(src)
-            log.info(f"using symlink target {src} for bind of {bind.host}")
-        
-        # make directory if needed
-        if bind.mkdir:
-            # I think files can be bound too, so only do this check for directories
-            if os.path.exists(src):
-                if not os.path.isdir(src):
-                    raise BackendError(f"host bind {bind.host} is not a directory")
-            else:
-                try:
-                    pathlib.Path(src).mkdir(parents=True)
-                except Exception as exc:
-                    raise BackendError(f"error creating directory for host bind {bind.host}", exc)
+            # expand ~ in paths
+            src = os.path.expanduser(bind.host).rstrip("/")
+            dest = os.path.expanduser(bind.target or src).rstrip("/")
+            rw = bind.mode == ReadWrite.rw
+
+            # handle binding of empty temp dirs
+            if bind.host == "empty":
+                if not bind.target:
+                    raise BackendError(f"bind_dirs.{label}: a target must be specified when host=empty")
+                tmpdir = TemporaryDirectory()
+                src = tmpdir.name
+                exit_stack.enter_context(tmpdir)
+                log.info(f"bind_dirs.{label}: using temporary directory {src}")
+
+            # resolve symlinks
+            if os.path.realpath(src) != src:
+                src = os.path.realpath(src)
+                log.info(f"bind_dirs.{label}: binding symlink target {src}")
             
-        # if already present in mounts, potentially upgrade to rw
-        mounts[src] = mounts.get(src, False) or rw
-        # if paths different, create a remapping
-        if src != dest:
-            if dest in container_to_host_path:
-                if container_to_host_path[dest] != src:
-                    raise BackendError(f"bind_dirs: conflicting bind paths for {dest}")
+            # make directory if needed
+            if bind.mkdir:
+                # I think files can be bound too, so only do this check for directories
+                if os.path.exists(src):
+                    if not os.path.isdir(src):
+                        raise BackendError(f"bind_dirs.{label}: host path is not a directory")
+                else:
+                    try:
+                        pathlib.Path(src).mkdir(parents=True)
+                    except Exception as exc:
+                        raise BackendError(f"bind_dirs.{label}: error creating directory {bind.host}", exc)
+                
+            # if already present in mounts, potentially upgrade to rw
+            mounts[src] = mounts.get(src, False) or rw
+            # if paths different, create a remapping
+            if src != dest:
+                if dest in container_to_host_path:
+                    if container_to_host_path[dest] != src:
+                        raise BackendError(f"bind_dirs.{label}: conflicting bind paths for {dest}")
+                else:
+                    container_to_host_path[dest] = src
+
+        # get extra required filesystem bindings from supplied parameters
+        resolve_required_mounts(mounts, params, cab.inputs, cab.outputs, remappings=container_to_host_path)
+
+        # redo mounts as a list of (container_path, source_path, rw)
+        source_to_containter_path = {src: dest for dest, src in container_to_host_path.items()}
+        mounts = [(source_to_containter_path.get(src, src), src, rw) for src, rw in mounts.items()]
+
+        # sort mount paths before iterating -- this ensures that parent directories come first
+        # (singularity doesn't like it if you specify a bind of a subdir before a bind of a parent) 
+        for dest, src, rw in sorted(mounts):
+            mode = 'rw' if rw else 'ro'
+            if src == dest:
+                log.info(f"binding {src} as {mode}")
             else:
-                container_to_host_path[dest] = src
+                log.info(f"binding {src} to {dest} as {mode}")
+            args += ["--bind", f"{src}:{dest}:{mode}"]
 
-    # get extra required filesystem bindings from supplied parameters
-    resolve_required_mounts(mounts, params, cab.inputs, cab.outputs, remappings=container_to_host_path)
+        args += [simg_path]
+        log_args = args.copy()
 
-    # redo mounts as a list of (container_path, source_path, rw)
-    source_to_containter_path = {src: dest for dest, src in container_to_host_path.items()}
-    mounts = [(source_to_containter_path.get(src, src), src, rw) for src, rw in mounts.items()]
+        args1, log_args1 = cab.flavour.get_arguments(cab, params, subst, check_executable=False)
+        args += args1
+        log_args += log_args1
 
-    # sort mount paths before iterating -- this ensures that parent directories come first
-    # (singularity doesn't like it if you specify a bind of a subdir before a bind of a parent) 
-    for dest, src, rw in sorted(mounts):
-        mode = 'rw' if rw else 'ro'
-        if src == dest:
-            log.info(f"binding {src} as {mode}")
+        cabstat = cab.reset_status()
+
+        command_name = f"{cab.flavour.command_name}" or None
+
+        # run command
+        start_time = datetime.datetime.now()
+        def elapsed(since=None):
+            """Returns string representing elapsed time"""
+            return str(datetime.datetime.now() - (since or start_time)).split('.', 1)[0]
+
+        # log.info(f"argument lengths are {[len(a) for a in args]}")
+
+        if wrapper:
+            args, log_args = wrapper.wrap_run_command(args, log_args, fqname=fqname, log=log)
+
+        log.debug(f"command line is {' '.join(log_args)}")
+
+        retcode = xrun(args[0], args[1:], shell=False, log=log,
+                    output_wrangler=cabstat.apply_wranglers,
+                    return_errcode=True, command_name=command_name, 
+                    gentle_ctrl_c=True,
+                    log_command=' '.join(log_args), 
+                    log_result=False)
+
+        # check if output marked it as a fail
+        if cabstat.success is False:
+            log.error(f"declaring '{command_name}' as failed based on its output")
+
+        # if retcode != 0 and not explicitly marked as success, mark as failed
+        if retcode and cabstat.success is not True:
+            cabstat.declare_failure(f"{command_name} returns error code {retcode} after {elapsed()}")
         else:
-            log.info(f"binding {src} to {dest} as {mode}")
-        args += ["--bind", f"{src}:{dest}:{mode}"]
+            log.info(f"{command_name} returns exit code {retcode} after {elapsed()}")
 
-    args += [simg_path]
-    log_args = args.copy()
-
-    args1, log_args1 = cab.flavour.get_arguments(cab, params, subst, check_executable=False)
-    args += args1
-    log_args += log_args1
-
-    cabstat = cab.reset_status()
-
-    command_name = f"{cab.flavour.command_name}" or None
-
-    # run command
-    start_time = datetime.datetime.now()
-    def elapsed(since=None):
-        """Returns string representing elapsed time"""
-        return str(datetime.datetime.now() - (since or start_time)).split('.', 1)[0]
-
-    # log.info(f"argument lengths are {[len(a) for a in args]}")
-
-    if wrapper:
-        args, log_args = wrapper.wrap_run_command(args, log_args, fqname=fqname, log=log)
-
-    log.debug(f"command line is {' '.join(log_args)}")
-
-    retcode = xrun(args[0], args[1:], shell=False, log=log,
-                output_wrangler=cabstat.apply_wranglers,
-                return_errcode=True, command_name=command_name, 
-                gentle_ctrl_c=True,
-                log_command=' '.join(log_args), 
-                log_result=False)
-
-    # check if output marked it as a fail
-    if cabstat.success is False:
-        log.error(f"declaring '{command_name}' as failed based on its output")
-
-    # if retcode != 0 and not explicitly marked as success, mark as failed
-    if retcode and cabstat.success is not True:
-        cabstat.declare_failure(f"{command_name} returns error code {retcode} after {elapsed()}")
-    else:
-        log.info(f"{command_name} returns exit code {retcode} after {elapsed()}")
-
-    return cabstat
+        return cabstat
 
 
 # class SingularityError(Exception):

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -298,10 +298,10 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
             # I think files can be bound too, so only do this check for directories
             if os.path.exists(src):
                 if not os.path.isdir(src):
-                    raise BackendError(f"host bind {bind.host} is not a directory", exc)
+                    raise BackendError(f"host bind {bind.host} is not a directory")
             else:
                 try:
-                    pathlib.Path.mkdir(src, parents=True)
+                    pathlib.Path(src).mkdir(parents=True)
                 except Exception as exc:
                     raise BackendError(f"error creating directory for host bind {bind.host}", exc)
             

--- a/stimela/backends/slurm.py
+++ b/stimela/backends/slurm.py
@@ -41,7 +41,7 @@ class SlurmOptions(object):
                 raise BackendError(f"slurm.srun_path '{self.srun}' is not an executable")
             return self.srun
         
-    def _wrap(self, srun_opts: Dict[str, Any], args: List[str], fqname: Optional[str]=None) -> List[str]:
+    def _wrap(self, srun_opts: Dict[str, Any], args: List[str],  log_args: List[str], fqname: Optional[str]=None) -> List[str]:
         output_args = [self.get_executable()]
 
         # reverse fqname to make job name (more informative that way)
@@ -52,11 +52,10 @@ class SlurmOptions(object):
         for name, value in srun_opts.items():
             output_args += ["--" + name, value]
 
-        output_args += args
-        return output_args
+        return output_args + args, output_args + log_args
 
-    def wrap_run_command(self, args: List[str], fqname: Optional[str]=None, log: Optional[logging.Logger]=None) -> List[str]:
-        return self._wrap(self.srun_opts, args, fqname)        
+    def wrap_run_command(self, args: List[str], log_args: List[str], fqname: Optional[str]=None, log: Optional[logging.Logger]=None) -> List[str]:
+        return self._wrap(self.srun_opts, args, log_args, fqname)        
 
     def wrap_build_command(self, args: List[str], fqname: Optional[str]=None, log: Optional[logging.Logger]=None) -> List[str]:
         if self.build_local:

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -265,7 +265,6 @@ class Step:
                 self.backend or {}))
             runner.validate_backend_settings(backend_opts, log=log)
 
-
     def prevalidate(self, subst: Optional[SubstitutionNS]=None, root=False, backend=None):
         self.finalize(backend=backend)
         # apply dynamic schemas

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -387,7 +387,8 @@ class Step:
         # validate backend settings
         try:
             backend_opts = OmegaConf.merge(self.config.opts.backend, backend)
-            backend_opts = evaluate_and_substitute_object(backend_opts, subst, recursion_level=-1, location=[self.fqname, "backend"])
+            backend_opts = evaluate_and_substitute_object(backend_opts, subst, 
+                                                          recursion_level=-1, location=[self.fqname, "backend"])
             if not is_outer_step and backend_opts.verbose:
                 opts_yaml = OmegaConf.to_yaml(backend_opts)
                 log_rich_payload(self.log, "current backend settings are", opts_yaml, syntax="yaml") 
@@ -415,7 +416,8 @@ class Step:
             # evaluate the skip attribute (it can be a formula and/or a {}-substititon)
             skip = self._skip
             if self._skip is None and subst is not None:
-                skip = evaluate_and_substitute_object(self.skip, subst, location=[self.fqname, "skip"])
+                skip = evaluate_and_substitute_object(self.skip, subst, 
+                                                      location=[self.fqname, "skip"])
                 if skip is UNSET:  # skip: =IFSET(recipe.foo) will return UNSET
                     skip = False
                 self.log.debug(f"dynamic skip attribute evaluation returns {skip}")


### PR DESCRIPTION
Other fixes:

Throw substitution errors when they arise in backend settings (this was meant to be done, but wasn't actually happening due to a bug).

Print/log more friendly command lines when running python and casa flavour cabs.