### PR TITLE
Issue 384

### DIFF
--- a/scabha/basetypes.py
+++ b/scabha/basetypes.py
@@ -49,7 +49,7 @@ class UNSET(Unresolved):
     pass
 
 class Placeholder(Unresolved):
-    """Marks placeholder values that are guaranteed to resolve later, such as fot-loop iterants"""
+    """Marks placeholder values that are guaranteed to resolve later, such as for-loop iterants"""
     pass
 
 class SkippedOutput(Unresolved):
@@ -145,7 +145,7 @@ def get_filelikes(dtype, value, filelikes=None):
 
     filelikes = set() if filelikes is None else filelikes
 
-    if value is UNSET or type(value) is UNSET:
+    if value is UNSET or isinstance(value, Unresolved):
       return []
       
     origin = get_origin(dtype)

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -165,6 +165,12 @@ class FunctionHandler(ResultsHandler):
             return unsets[0]
         return callable(*eval_args)
 
+    def ERROR(self, evaluator, args):
+        if len(args) != 1:
+            raise FormulaError(f"{'.'.join(evaluator.location)}: ERROR() expects one argument, got {len(args)}")
+        cond = evaluator._evaluate_result(args[0], allow_unset=True)
+        raise FormulaError(f"ERROR: {cond}")
+
     def LIST(self, evaluator, args):
         def make_list(*x):
             return list(x)
@@ -206,6 +212,24 @@ class FunctionHandler(ResultsHandler):
         def is_num(x):
             return isinstance(x, (bool, int, float, complex)) 
         return self.evaluate_generic_callable(evaluator, "IS_NUM", is_num, args, min_args=1, max_args=1)
+    
+    def CASES(self, evaluator, args):
+        # set default case
+        if len(args)%2:
+            default_case = args[-1]
+            args = args[:-1]
+        else: 
+            default_case = None
+        # return first True case
+        for i in range(0, len(args), 2):
+            conditional, result = args[i:i+2]
+            cond = evaluator._evaluate_result(conditional, allow_unset=False)
+            if cond:
+                return evaluator._evaluate_result(result, allow_unset=True)
+        # return default
+        if default_case is None:
+            return UNSET("no match in CASES()")
+        return evaluator._evaluate_result(default_case, allow_unset=True)
 
     def IF(self, evaluator, args):
         if len(args) < 3 or len(args) > 4:
@@ -342,11 +366,15 @@ def construct_parser():
     # allow expression to be used recursively
     expr = Forward()
     
-    # functions
-    functions = reduce(operator.or_, map(Keyword, ["IF", "IFSET", "GLOB", "EXISTS", "LIST", "GETITEM",
-        "BASENAME", "DIRNAME", "EXTENSION", "STRIPEXT", "MIN", "MAX", "IS_STR", "IS_NUM", "VALID", "RANGE", "NOSUBST", "SORT", "RSORT"]))
+    # functions -- get all all-uppercase members from FunctionHandler
+    anyseq_funcnames = {"GLOB", "EXISTS", "ERROR"}
+    all_funcnames = set(func for func in dir(FunctionHandler) 
+                        if callable(getattr(FunctionHandler, func)) and func.upper() == func)
+    all_funcnames -= anyseq_funcnames
+
+    functions = reduce(operator.or_, map(Keyword, all_funcnames))
     # these functions take one argument, which could also be a sequence
-    anyseq_functions = reduce(operator.or_, map(Keyword, ["GLOB", "EXISTS"]))
+    anyseq_functions = reduce(operator.or_, map(Keyword, anyseq_funcnames))
 
     atomic_value = (boolean | UNSET | EMPTY | nested_field | string | number)
 

--- a/stimela/stimela.conf
+++ b/stimela/stimela.conf
@@ -5,11 +5,11 @@ images:
     default-python: 
         registry: quay.io/stimela2
         name: python-astro
-        version: cc0.1.3
+        version: cc0.2.0
     default-casa: 
         registry: quay.io/stimela2
         name: casa
-        version: cc0.1.3
+        version: cc0.2.0
 
 opts:
     runtime:

--- a/tests/scabha_tests/test_substitutions.py
+++ b/tests/scabha_tests/test_substitutions.py
@@ -139,7 +139,13 @@ def test_formulas():
         u1 = '=SORT(current.u)',
         u2 = '=RSORT(current.u)',
         u3 = '=GETITEM(current.u, 1)',
-        u4 = '=current.u[previous.x]'
+        u4 = '=current.u[previous.x]',
+        v1 = '=CASES(previous.x == 0, deliberately.unset.thats.ok, previous.x == 1, 1)',
+        v2 = '=CASES(previous.x == 1, 2, previous.x == 2, 2)',
+        v3 = '=CASES(previous.x == 0, 0, previous.x == 2, 2, 3)',
+        v4 = '=CASES(previous.x == 0, 0, previous.x == 2, 2)',
+        v5 = '=ERROR(boom!)',
+        v6 = '=ERROR(boom!)',
     )
     ns._add_("current", current)
     
@@ -149,6 +155,7 @@ def test_formulas():
         results = evaltor.evaluate_dict(current, corresponding_ns=ns.current, raise_substitution_errors=False, verbose=True)
 
         r = results
+        print(r.keys())
 
         assert r['a'] == "a1"
         assert r['b'] == "=escaped"
@@ -170,6 +177,10 @@ def test_formulas():
         assert r['q'] == ["a1", "=escaped", 2, 0]
         assert r['r'] == False
         assert r['t'] == 'zz'
+        assert r['v1'] == 1
+        assert r['v2'] == 2
+        assert r['v3'] == 3
+        assert type(r['v4']) is UNSET
 
 if __name__ == "__main__":
     test_subst()


### PR DESCRIPTION
This supercedes #381, but you can review them in turn as well @JSKenyon.

This adds a ``TRY()`` as discussed in #375.

I've also cleaned up handling of ``Unresolved`` values. Old pattern was ``type(x) is UNSET`` which only handled a subset of the unresolved-value conditions (``Unresolved`` is a parent class of ``UNSET`` for all unresolved conditions, see ``scabha/basetypes.py``).