### PR TITLE
Add more fully featured custom console print.

### DIFF
--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -21,6 +21,24 @@ from warnings import warn
 
 from . import task_stats
 
+CONSOLE_PRINT_OPTIONS = [
+    "sep",
+    "end",
+    "style",
+    "justify",
+    "overflow",
+    "no_wrap",
+    "emoji",
+    "markup",
+    "highlight",
+    "width",
+    "height",
+    "crop",
+    "soft_wrap",
+    "new_line_start"
+]
+
+
 class FunkyMessage(object):
     """Class representing a message with two versions: funky (with markup), and boring (no markup)"""
     def __init__(self, funky, boring=None, prefix=None, escape_emojis=True):
@@ -49,6 +67,14 @@ class StimelaConsoleHander(rich.logging.RichHandler):
         self._console = console
 
     def emit(self, record):
+        # NOTE(JSKenyon): If a message requires a custom console print,
+        # forward all known arguments to the _console.print method.
+        if getattr(record, "custom_console_print", False) == True:
+            self._console.print(
+                record.msg,
+                **{k: getattr(record, k) for k in CONSOLE_PRINT_OPTIONS if hasattr(record, k)}
+            )
+            return
         try:
             rich.logging.RichHandler.emit(self, record)
         # backstop -- message should have been properly markup-escaped

--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -69,7 +69,7 @@ class StimelaConsoleHander(rich.logging.RichHandler):
     def emit(self, record):
         # NOTE(JSKenyon): If a message requires a custom console print,
         # forward all known arguments to the _console.print method.
-        if getattr(record, "custom_console_print", False) == True:
+        if getattr(record, "custom_console_print", False):
             self._console.print(
                 record.msg,
                 **{k: getattr(record, k) for k in CONSOLE_PRINT_OPTIONS if hasattr(record, k)}

--- a/stimela/utils/xrun_asyncio.py
+++ b/stimela/utils/xrun_asyncio.py
@@ -81,11 +81,16 @@ def xrun(command, options, log=None, env=None, timeout=-1, kill_callback=None, o
     log = log or stimela.logger()
 
     if log_command:
+        # NOTE(JSKenyon): These must be logged with soft wrapping to make
+        # copy pasting the output simple.
+        extras = dict(custom_console_print=True, style="dim", soft_wrap=True)
         if log_command is True:
-            log.info(f"running {command_line}", extra=dict(prefix="###", style="dim"))
+            log.info("---INVOKING---", extra=dict(**extras, justify="center"))
+            log.info(f"{command_line}\n", extra=extras)
         else:
-            log.info(f"running {log_command}", extra=dict(prefix="###", style="dim"))
-            log.debug(f"full command line is {command_line}", extra=dict(prefix="###", style="dim"))
+            log.info("---INVOKING---", extra=dict(**extras, justify="center"))
+            log.info(f"{log_command}\n", extra=extras)
+            log.debug(f"full command line is {command_line}", extra=extras)
 
     with task_stats.declare_subcommand(os.path.basename(command_name)) as command_context:
 

--- a/tests/stimela_tests/test_conditional_skips.py
+++ b/tests/stimela_tests/test_conditional_skips.py
@@ -7,50 +7,50 @@ def test_conditional_skips():
     retcode, output = run("stimela -b native run test_conditional_skips.yml")
     assert retcode == 0
     print(output)
-    assert verify_output(output, "running touch test_conditional_skips1.tmp")
-    assert verify_output(output, "running touch test_conditional_skips2.tmp")
-    assert verify_output(output, "running touch test_conditional_skips3.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips1.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips2.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips3.tmp")
 
     print("===== 2 and 3 touched =====")
     os.system("touch test_conditional_skips4.tmp")
     retcode, output = run("stimela -b native run test_conditional_skips.yml")
     assert retcode == 0
     print(output)
-    assert not verify_output(output, "running touch test_conditional_skips1.tmp")
-    assert verify_output(output, "running touch test_conditional_skips2.tmp")
-    assert verify_output(output, "running touch test_conditional_skips3.tmp")
+    assert not verify_output(output, "---INVOKING---", "touch test_conditional_skips1.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips2.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips3.tmp")
 
     print("===== only 3 touched =====")
     retcode, output = run("stimela -b native run test_conditional_skips.yml")
     assert retcode == 0
     print(output)
-    assert not verify_output(output, "running touch test_conditional_skips1.tmp")
-    assert not verify_output(output, "running touch test_conditional_skips2.tmp")
-    assert verify_output(output, "running touch test_conditional_skips3.tmp")
+    assert not verify_output(output, "---INVOKING---", "touch test_conditional_skips1.tmp")
+    assert not verify_output(output, "---INVOKING---", "touch test_conditional_skips2.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips3.tmp")
 
     print("===== 2 and 3 touched =====")
     retcode, output = run("stimela -b native run test_conditional_skips.yml -f")
     assert retcode == 0
     print(output)
-    assert not verify_output(output, "running touch test_conditional_skips1.tmp")
-    assert verify_output(output, "running touch test_conditional_skips2.tmp")
-    assert verify_output(output, "running touch test_conditional_skips3.tmp")
+    assert not verify_output(output, "---INVOKING---", "touch test_conditional_skips1.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips2.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips3.tmp")
 
     print("===== 1 and 3 touched =====")
     retcode, output = run("stimela -b native run test_conditional_skips.yml -F")
     assert retcode == 0
     print(output)
-    assert verify_output(output, "running touch test_conditional_skips1.tmp")
-    assert not verify_output(output, "running touch test_conditional_skips2.tmp")
-    assert verify_output(output, "running touch test_conditional_skips3.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips1.tmp")
+    assert not verify_output(output, "---INVOKING---", "touch test_conditional_skips2.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips3.tmp")
 
     print("===== all three files touched =====")
     retcode, output = run("stimela -b native run test_conditional_skips.yml -f -F")
     assert retcode == 0
     print(output)
-    assert verify_output(output, "running touch test_conditional_skips1.tmp")
-    assert verify_output(output, "running touch test_conditional_skips2.tmp")
-    assert verify_output(output, "running touch test_conditional_skips3.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips1.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips2.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_conditional_skips3.tmp")
 
     print("===== cleaning up =====")
     os.system("rm -fr test_conditional_skips[1234].tmp")


### PR DESCRIPTION
Currently the `### running command...` log messages are difficult to copy and paste due to the inclusion of newline characters. This PR removes wrapping/newline characters from the relevant messages as well as makes them more obvious in the logs. As part of this fix, messages may include a `custom_console_print=True` which means the message will not be handled by the `rich.logging.RichHandler.emit` method and instead be printed directly using the `self._console.print` method. The new code will forward all known arguments to the `self._console.print` method from the extras included on the record object.