### PR TITLE
Attempt to update and improve URI handling.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ psutil = "^5.9.3"
 rich = "^13.7.0"
 dill = "^0.3.6"
 typeguard = "^4.2.1"
+uritools = "^5.0.0"
 
 [tool.poetry.scripts]
 stimela = "stimela.main:cli"

--- a/scabha/basetypes.py
+++ b/scabha/basetypes.py
@@ -10,6 +10,8 @@ from typeguard import (
     check_type, TypeCheckError, TypeCheckerCallable, TypeCheckMemo, checker_lookup_functions
 )
 from inspect import isclass
+import uritools
+from pathlib import Path
 
 
 def EmptyDictDefault():
@@ -59,26 +61,33 @@ class SkippedOutput(Unresolved):
 
 class URI(str):
     def __init__(self, value):
-        self.protocol, self.path, self.remote = URI.parse(value)
 
-    @staticmethod
-    def parse(value: str, expand_user=True):
-        """
-        Parses URI. If URI does not start with "protocol://", assumes "file://"
+        uri_components = uritools.urisplit(value)
+        self.scheme = uri_components.scheme or "file"  # Protocol.
+        self.authority = uri_components.authority
+        self.query = uri_components.query
+        self.fragment = uri_components.fragment
 
-        Returns tuple of (protocol, path, is_remote)
-
-        If expand_user is True, ~ in (file-protocol) paths will be expanded.
-        """
-        match = re.fullmatch(r'((\w+)://)(.*)', value)
-        if not match:
-            protocol, path, remote = "file", value, False
+        if self.scheme == "file":
+            self.path = str(Path(uri_components.path).expanduser().absolute())
         else:
-            _, protocol, path = match.groups()
-            remote = protocol != "file"
-        if not remote and expand_user:
-            path = os.path.expanduser(path)
-        return protocol, path, remote
+            self.path = uri_components.path
+
+        self.full_uri = uritools.uricompose(
+            scheme=self.scheme,
+            authority=self.authority,
+            path=self.path,
+            query=self.query,
+            fragment=self.fragment
+        )
+
+        self.remote = self.scheme != "file"
+
+    def __str__(self):
+        return self.full_uri if self.remote else self.path
+
+    def __repr__(self):
+        return self.full_uri
 
 
 class File(URI):

--- a/tests/stimela_tests/test_recipe.yml
+++ b/tests/stimela_tests/test_recipe.yml
@@ -121,11 +121,11 @@ recipe:
       default: ['.', '..', '~']
     recipe-uri:
       dtype: URI
-      default: file://test_recipe.yml
+      default: file:test_recipe.yml  # Somewhat unusual - relative URI.
       must_exist: true
     recipe-uri-2:
       dtype: List[URI]
-      default: [file://test_recipe.yml, s3://some.s3.path]
+      default: [file:test_recipe.yml, s3://some.s3.path]
       must_exist: true
   outputs:
     output-dir:    


### PR DESCRIPTION
This PR is my attempt at improving URI handling. I was running into problems when specifying an `MS` type input via the command line when including relative paths e.g. `~/path/to/ms`. The existing URI class is a little odd in that it subclasses `str`, but doesn't update its `__repr__` or `__str__` methods so although the URI is parsed correctly, calling `str(uri_obj)` will always return the input string. This results in parameters entering the command with unresolved relative paths which is problematic as `$HOME` may not be the same inside and outside the container. This PR attempts to overhaul the base URI class to make use of `uritools`. This should be more robust and leave room for more advanced functionality in the future. Note that I have removed the `parse` method in favour of a more comprehensive `__init__` (which I believe is harmless as I cannot see any invocations of `URI.parse` in the code). Finally, I have removed the optional `expand_user` option - this appeared to be unused and I cannot think of a situation in which we would want to disable this functionality (but feel free to disagree).   