### PR TITLE
escape omegaconf interpolation in git info string

### DIFF
--- a/scabha/configuratt/deps.py
+++ b/scabha/configuratt/deps.py
@@ -124,7 +124,7 @@ class ConfigDependencies(object):
         for line in branches.decode().split("\n"):
             line = line.strip()
             if line.startswith("*"):
-                gitinfo.branch = line[1:].strip()
+                gitinfo.branch = line[1:].strip().replace("${", "\\${")
                 break
         # get description
         try:


### PR DESCRIPTION
This is a band-aid for a more pernicious problem (though perhaps not so pernicious, seeing as it's been there forever and nobody tripped over it)...

I had referenced "${}-interpolation" in my git commit message. The dependency dict that stimela accumulates inserts the git commit message into the dict -- the "${}" then tripped an error in the interpolation lexer. :facepalm:

This fix applies an escape string -- but more generally, text containing "${}" will trip strange errors when assigned to an OmegaConf dict. It might be a helluva job to sanitize every assignment...
