### PR TITLE
Enable console in casatasks and delete extra log

### DIFF
--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -40,11 +40,12 @@ class SingularityBackendOptions(object):
     containall: bool = False       # if True, runs with --containall
     bind_tmp: bool = True          # if True, implicitly binds an empty /tmp directory
     clean_tmp: bool = True         # if False, temporary directories will not be cleaned up. Useful for debugging.
+    bind_logdir: bool = True       # if False, the current stimela logdir will not be bound
 
     # optional extra bindings
     bind_dirs: Dict[str, BindDir] = EmptyDictDefault()
     env: Dict[str, str] = EmptyDictDefault()
-    
+
 
 SingularityBackendSchema = OmegaConf.structured(SingularityBackendOptions)
 
@@ -84,7 +85,7 @@ def is_available(opts: Optional[SingularityBackendOptions] = None):
                 #     suffix = ".sif"
             else:
                 STATUS = "not installed"
-                VERSION = None    
+                VERSION = None
     return VERSION is not None
 
 def get_status():
@@ -119,10 +120,10 @@ def get_image_info(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.Sti
 
     if not image_name:
         raise BackendError(f"cab '{cab.name}' does not define an image")
-    
+
     # convert to filename
     simg_name = image_name.replace("/", "-") + ".simg"
-    simg_path = os.path.join(backend.singularity.image_dir, simg_name) 
+    simg_path = os.path.join(backend.singularity.image_dir, simg_name)
 
     return image_name, simg_path
 
@@ -152,10 +153,10 @@ def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBacke
     image_name, simg_path = get_image_info(cab, backend)
 
     # this is True if we're allowed to build missing images
-    build = build or rebuild or backend.singularity.auto_build   
+    build = build or rebuild or backend.singularity.auto_build
     # this is True if we're asked to force-rebuild images
     rebuild = rebuild or backend.singularity.rebuild
-    
+
     cached_image_exists = os.path.exists(simg_path)
 
     # no image? Better have builds enabled then
@@ -170,14 +171,14 @@ def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBacke
             log.info(f"singularity image {simg_path} was rebuilt earlier")
         else:
             log.info(f"singularity image {simg_path} exists but a rebuild was specified")
-            os.unlink(simg_path)        
+            os.unlink(simg_path)
             cached_image_exists = False
     else:
         log.info(f"singularity image {simg_path} exists")
 
     ## OMS: taking this out for now, need some better auto-update logic, let's come back to it later
     ## Please retain the code for now
-        
+
     # # else check if it need to be auto-updated
     # elif auto_update_allowed and backend.singularity.auto_update:
     #     if image_name in _auto_updated_images:
@@ -192,13 +193,13 @@ def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBacke
     #         else:
     #             log.info("singularity auto-update: pulling and inspecting docker image")
     #             # pull image from hub
-    #             retcode = xrun(docker.BINARY, ["pull", image_name], 
+    #             retcode = xrun(docker.BINARY, ["pull", image_name],
     #                         shell=False, log=log,
-    #                             return_errcode=True, command_name="(docker pull)", 
-    #                             log_command=True, 
+    #                             return_errcode=True, command_name="(docker pull)",
+    #                             log_command=True,
     #                             log_result=True)
     #             if retcode != 0:
-    #                 raise BackendError(f"docker pull failed with return code {retcode}") 
+    #                 raise BackendError(f"docker pull failed with return code {retcode}")
     #             if os.path.exists(simg_path):
     #                 # check timestamp
     #                 result = subprocess.run(
@@ -224,7 +225,7 @@ def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBacke
 
     #                 if dt.timestamp() > os.path.getmtime(simg_path):
     #                     log.warn("docker image is newer than cached singularity image, rebuilding")
-    #                     os.unlink(simg_path)        
+    #                     os.unlink(simg_path)
     #                     cached_image_exists = False
     #                 else:
     #                     log.info("cached singularity image appears to be up-to-date")
@@ -240,9 +241,9 @@ def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBacke
             args = wrapper.wrap_build_command(args, log=log)
 
         retcode = xrun(args[0], args[1:], shell=False, log=log,
-                    return_errcode=True, command_name="(singularity build)", 
+                    return_errcode=True, command_name="(singularity build)",
                     gentle_ctrl_c=True,
-                    log_command=' '.join(args), 
+                    log_command=' '.join(args),
                     log_result=True)
 
         if retcode:
@@ -250,9 +251,9 @@ def build(cab: 'stimela.kitchen.cab.Cab', backend: 'stimela.backend.StimelaBacke
 
         if not os.path.exists(simg_path):
             raise BackendError(f"singularity build did not return an error code, but the image did not appear")
-        
+
         _rebuilt_images.add(simg_path)
-        
+
     return simg_path
 
 
@@ -279,10 +280,10 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
     # get path to image, rebuilding if backend options allow this
     simg_path = build(cab, backend=backend, log=log, build=False, wrapper=wrapper)
 
-    # build up command line    
+    # build up command line
     cwd = os.getcwd()
-    args = [backend.singularity.executable or BINARY, 
-            "exec", 
+    args = [backend.singularity.executable or BINARY,
+            "exec",
             "--pwd", cwd]
     if backend.singularity.containall:
         args.append("--containall")
@@ -296,7 +297,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
     # dict of container paths to host paths
     container_to_host_path = {}
 
-    with ExitStack() as exit_stack: 
+    with ExitStack() as exit_stack:
         # add extra binds
         for label, bind in backend.singularity.bind_dirs.items():
             # skip if conditional is False
@@ -321,7 +322,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
             if os.path.realpath(src) != src:
                 src = os.path.realpath(src)
                 log.info(f"bind_dirs.{label}: binding symlink target {src}")
-            
+
             # make directory if needed
             if bind.mkdir:
                 # I think files can be bound too, so only do this check for directories
@@ -333,7 +334,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
                         pathlib.Path(src).mkdir(parents=True)
                     except Exception as exc:
                         raise BackendError(f"bind_dirs.{label}: error creating directory {bind.host}", exc)
-                
+
             # if already present in mounts, potentially upgrade to rw
             mounts[src] = mounts.get(src, False) or rw
             # if paths different, create a remapping
@@ -343,6 +344,18 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
                         raise BackendError(f"bind_dirs.{label}: conflicting bind paths for {dest}")
                 else:
                     container_to_host_path[dest] = src
+
+        if backend.singularity.bind_logdir:
+            if not isinstance(log, logging.Logger):
+                raise ValueError("Cannot bind log directory without a valid logger.")
+
+            file_handler = next((h for h in log.handlers if isinstance(h, logging.FileHandler)), None)
+
+            if file_handler is None:
+                logging.warning("No file handler has been configured - bind_logdir will be ignored.")
+            else:
+                log_dir = file_handler.get_logfile_dir()
+                mounts[log_dir] = True  # Needs to be writable.
 
         # get extra required filesystem bindings from supplied parameters
         resolve_required_mounts(mounts, params, cab.inputs, cab.outputs, remappings=container_to_host_path)
@@ -363,7 +376,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
                 mounts.append(("/tmp", tmpdir_name, True))
 
         # sort mount paths before iterating -- this ensures that parent directories come first
-        # (singularity doesn't like it if you specify a bind of a subdir before a bind of a parent) 
+        # (singularity doesn't like it if you specify a bind of a subdir before a bind of a parent)
         for dest, src, rw in sorted(mounts):
             mode = 'rw' if rw else 'ro'
             if src == dest:
@@ -398,9 +411,9 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
 
         retcode = xrun(args[0], args[1:], shell=False, log=log,
                     output_wrangler=cabstat.apply_wranglers,
-                    return_errcode=True, command_name=command_name, 
+                    return_errcode=True, command_name=command_name,
                     gentle_ctrl_c=True,
-                    log_command=' '.join(log_args), 
+                    log_command=' '.join(log_args),
                     log_result=False)
 
         # check if output marked it as a fail
@@ -420,7 +433,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
 #     pass
 
 # def pull(image, name, docker=True, directory=".", force=False):
-#     """ 
+#     """
 #         pull an image
 #     """
 #     if docker:
@@ -434,8 +447,8 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
 #     if os.path.exists(image_path) and not force:
 #         stimela.logger().info(f"Singularity image already exists at '{image_path}'. To replace it, please re-run with the 'force' option")
 #     else:
-#         utils.xrun(f"cd {directory} && singularity", ["pull", 
-#         	"--force" if force else "", "--name", 
+#         utils.xrun(f"cd {directory} && singularity", ["pull",
+#         	"--force" if force else "", "--name",
 #          	name, fp])
 
 #     return 0
@@ -489,7 +502,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
 #                     "in container {2}".format(key, value, self.name))
 #         self.environs.append("=".join([key, value]))
 #         key_ = f"SINGULARITYENV_{key}"
-	
+
 #         self.logger.debug(f"Setting singularity environmental variable {key_}={value} on host")
 #         self._env[key_] = value
 
@@ -513,7 +526,7 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
 #         self.status = "running"
 #         self._print("Starting container [{0:s}]. Timeout set to {1:d}. The container ID is printed below.".format(
 #             self.name, self.time_out))
-        
+
 #         utils.xrun(f"cd {self.execdir} && singularity", ["run", "--workdir", self.execdir, "--containall"] \
 
 #                     + list(args) + [volumes, self.image, self.RUNSCRIPT],

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -40,7 +40,6 @@ class SingularityBackendOptions(object):
     containall: bool = False       # if True, runs with --containall
     bind_tmp: bool = True          # if True, implicitly binds an empty /tmp directory
     clean_tmp: bool = True         # if False, temporary directories will not be cleaned up. Useful for debugging.
-    bind_logdir: bool = True       # if False, the current stimela logdir will not be bound
 
     # optional extra bindings
     bind_dirs: Dict[str, BindDir] = EmptyDictDefault()
@@ -344,18 +343,6 @@ def run(cab: 'stimela.kitchen.cab.Cab', params: Dict[str, Any], fqname: str,
                         raise BackendError(f"bind_dirs.{label}: conflicting bind paths for {dest}")
                 else:
                     container_to_host_path[dest] = src
-
-        if backend.singularity.bind_logdir:
-            if not isinstance(log, logging.Logger):
-                raise ValueError("Cannot bind log directory without a valid logger.")
-
-            file_handler = next((h for h in log.handlers if isinstance(h, logging.FileHandler)), None)
-
-            if file_handler is None:
-                logging.warning("No file handler has been configured - bind_logdir will be ignored.")
-            else:
-                log_dir = file_handler.get_logfile_dir()
-                mounts[log_dir] = True  # Needs to be writable.
 
         # get extra required filesystem bindings from supplied parameters
         resolve_required_mounts(mounts, params, cab.inputs, cab.outputs, remappings=container_to_host_path)


### PR DESCRIPTION
Closes #440. @o-smirnov I would appreciate your input as while I believe that what I have done works, it is a somewhat bespoke solution.

I think that there is perhaps an argument to be made for having a separate flavour for `casatasks` (even if they are very similar to the `python` flavour) as we will inevitably have to patch in `casatask` specific workarounds in the future and it would be nice to do so without affecting the `python` flavour cabs. My current solution is untested for `casa5` cabs. 

Apologies for all the whitespace changes - I didn't realise until it was too late. 

Edit: The purpose of this PR is to automatically move casa logs to the appropriate place in the stimela log directory. 