### PR TITLE
Upgrade pre- and post-command fields to dictionaries.

### DIFF
--- a/docs/source/reference/cabdefs.rst
+++ b/docs/source/reference/cabdefs.rst
@@ -237,7 +237,7 @@ The following additional options are available for both the ``python`` and ``pyt
 
 * ``flavour.interpreter_command`` determines how the interpreter command line is formed, default is ``"{python} -u"``. Note that this is not subject to Stimela's full {}-substitutions, but does recognize ``{python}``, and inserts ``interpreter_binary`` as set above.
 
-* ``flavour.pre_commands`` adds optional Python code to be executed up front. This can be useful for housekeeping operations, such as disabling warnings, etc. Multiple commands can be specified and will be run in order.::
+* ``flavour.pre_commands`` adds optional Python code to be executed up front. This can be useful for housekeeping operations, such as disabling warnings, etc. Multiple commands can be specified as mappings from arbitrary command names (labels) to code strings and will be executed in order.::
 
     flavour:
         kind: python

--- a/docs/source/reference/cabdefs.rst
+++ b/docs/source/reference/cabdefs.rst
@@ -237,15 +237,16 @@ The following additional options are available for both the ``python`` and ``pyt
 
 * ``flavour.interpreter_command`` determines how the interpreter command line is formed, default is ``"{python} -u"``. Note that this is not subject to Stimela's full {}-substitutions, but does recognize ``{python}``, and inserts ``interpreter_binary`` as set above.
 
-* ``flavour.pre_command`` adds optional Python code to be executed up front. This can be useful for housekeeping operations, such as disabling warnings, etc.::
+* ``flavour.pre_commands`` adds optional Python code to be executed up front. This can be useful for housekeeping operations, such as disabling warnings, etc. Multiple commands can be specified and will be run in order.::
 
     flavour:
         kind: python
-        pre_command: |
-            import warnings         
-            warnings.filterwarnings("ignore", category=SyntaxWarning)                
+        pre_commands:
+            filter-warnings: |
+                import warnings
+                warnings.filterwarnings("ignore", category=SyntaxWarning)
 
-* ``flavour.post_command`` adds optional Python code to be executed after the command.
+* ``flavour.post_commands`` adds optional Python code to be executed after the command.
 
 casa-task
 ^^^^^^^^^

--- a/stimela/backends/flavours/python_flavours.py
+++ b/stimela/backends/flavours/python_flavours.py
@@ -157,10 +157,10 @@ class PythonCallableFlavour(_CallableFlavour):
 
         pre_command_str = ""
         if self.pre_commands:
-            pre_command_str += "".join(self.pre_commands.values())
+            pre_command_str += "\n".join(self.pre_commands.values())
         post_command_str = ""
         if self.post_commands:
-            post_command_str += "".join(self.post_commands.values())
+            post_command_str += "\n".join(self.post_commands.values())
 
         code = f"""
 import sys, json, zlib, base64
@@ -260,7 +260,7 @@ import sys, json
 {inp_dict} = json.loads(sys.argv[1])
 """
         if self.pre_commands:
-            pre_command_str += "".join(self.pre_commands.values())
+            pre_command_str += "\n".join(self.pre_commands.values())
 
         if self.input_vars:
             for name in pass_params:
@@ -279,7 +279,7 @@ import sys, json
                     post_command_str += f"yield_output(**{{'{name}': {var_name}}})\n"
         
         if self.post_commands:
-            post_command_str += "".join(self.post_commands.values())
+            post_command_str += "\n".join(self.post_commands.values())
 
         # form up interpreter invocation
         args = get_python_interpreter_args(cab, subst, virtual_env=virtual_env)

--- a/stimela/backends/flavours/python_flavours.py
+++ b/stimela/backends/flavours/python_flavours.py
@@ -91,9 +91,9 @@ class PythonCallableFlavour(_CallableFlavour):
     # Full command used to launch interpreter. {python} gets substituted for the interpreter path
     interpreter_command: str = "{python} -u"
     # commands run prior to invoking function
-    pre_command: Optional[str] = None
+    pre_commands: Optional[Dict[str, str]] = None
     # commands run post invoking function
-    post_command: Optional[str] = None
+    post_commands: Optional[Dict[str, str]] = None
 
     def finalize(self, cab: Cab):
         super().finalize(cab)
@@ -154,13 +154,21 @@ class PythonCallableFlavour(_CallableFlavour):
             msg4 = f"""print("## return value is ", _result)"""
         else:
             msg1 = msg2 = msg3 = msg4 = ""
+
+        pre_command_str = ""
+        if self.pre_commands:
+            pre_command_str += "".join(self.pre_commands.values())
+        post_command_str = ""
+        if self.post_commands:
+            post_command_str += "".join(self.post_commands.values())
+
         code = f"""
 import sys, json, zlib, base64
 _inputs = json.loads(zlib.decompress(
                         base64.b64decode(sys.argv[1].encode("ascii"))
                     ).decode("ascii"))
 sys.path.append('.')
-{self.pre_command or 'pass'}
+{pre_command_str}
 {msg1}
 from {py_module} import {py_function}
 try:
@@ -176,7 +184,7 @@ else:
 _result = {py_function}(**_inputs)
 {msg4}
 {self._yield_output}
-{self.post_command or 'pass'}
+{post_command_str}
         """
 
         args = get_python_interpreter_args(cab, subst, virtual_env=virtual_env)
@@ -203,9 +211,9 @@ class PythonCodeFlavour(_BaseFlavour):
     # Full command used to launch interpreter. {python} gets substituted for the interpreter path
     interpreter_command: str = "{python} -u"
     # commands run prior to invoking code
-    pre_command: Optional[str] = None
+    pre_commands: Optional[Dict[str, str]] = None
     # commands run post invoking code
-    post_command: Optional[str] = None
+    post_commands: Optional[Dict[str, str]] = None
 
     def finalize(self, cab: Cab):
         super().finalize(cab)
@@ -247,31 +255,32 @@ class PythonCodeFlavour(_BaseFlavour):
         params_arg = json.dumps(pass_params)
         inp_dict = self.input_dict or "_params"
 
-        pre_command = f"""import sys, json
+        pre_command_str = f"""
+import sys, json
 {inp_dict} = json.loads(sys.argv[1])
 """
-        if self.pre_command:
-            pre_command += self.pre_command
+        if self.pre_commands:
+            pre_command_str += "".join(self.pre_commands.values())
 
         if self.input_vars:
             for name in pass_params:
                 var_name = name.replace("-", "_").replace(".", "__")
-                pre_command += f"""{var_name} = {inp_dict}["{name}"]\n"""
+                pre_command_str += f"""{var_name} = {inp_dict}["{name}"]\n"""
 
         # form up code to print outputs in JSON
-        post_command = ""
+        post_command_str = ""
         pass_outputs = [name for name, schema in cab.outputs.items()
                         if not schema.is_named_output and not schema.implicit]
         if pass_outputs:
-            post_command += "from scabha.cab_utils import yield_output\n"
+            post_command_str += "from scabha.cab_utils import yield_output\n"
             if self.output_vars:
                 for name in pass_outputs:
                     var_name = name.replace("-", "_").replace(".", "__")
-                    post_command += f"yield_output(**{{'{name}': {var_name}}})\n"
+                    post_command_str += f"yield_output(**{{'{name}': {var_name}}})\n"
         
-        if self.post_command:
-            post_command += self.post_command
+        if self.post_commands:
+            post_command_str += "".join(self.post_commands.values())
 
         # form up interpreter invocation
         args = get_python_interpreter_args(cab, subst, virtual_env=virtual_env)
-        return args + ["-c", pre_command + command + post_command, params_arg], args + ["-c", "..."]
+        return args + ["-c", pre_command_str + command + post_command_str, params_arg], args + ["-c", "..."]

--- a/tests/stimela_tests/test_recipe.yml
+++ b/tests/stimela_tests/test_recipe.yml
@@ -70,7 +70,18 @@ cabs:
 
   test_callable:
     command: stimela_tests.test_recipe.callable_function
-    flavour: python
+    flavour:
+      kind: python
+      pre_commands:
+        pre-1: |
+          print("Pre-command 1...")
+        pre-2: |
+          print("Pre-command 2...")
+      post_commands:
+        post-1: |
+          print("Post-command 1...")
+        post-2: |
+          print("Post-command 2...")
     inputs:
       a:
         dtype: int

--- a/tests/stimela_tests/test_recipe.yml
+++ b/tests/stimela_tests/test_recipe.yml
@@ -73,13 +73,11 @@ cabs:
     flavour:
       kind: python
       pre_commands:
-        pre-1: |
-          print("Pre-command 1...")
+        pre-1: print("Pre-command 1...")
         pre-2: |
           print("Pre-command 2...")
       post_commands:
-        post-1: |
-          print("Post-command 1...")
+        post-1: print("Post-command 1...")
         post-2: |
           print("Post-command 2...")
     inputs:


### PR DESCRIPTION
Closes #442. This PR replaces `pre_command` and `post_command` with `pre_commands` and `post_commands` which accept dictionaries containing mappings from arbitrary name strings to Python code strings. This allows for multiple pre- and -post commands to be specified with descriptive labels e.g.:

```yaml
cabs:
  echo:
    flavour:
      kind: python-code
      pre_commands:
        echo-1: |
          print("1")
        echo-2: |
          print("2")
      post_commands:
        echo-4: |
          print("4")
        echo-5: |
          print("5")
    command: |
      print("3")
```

I decided to change the name so that it suggests that multiple commands can be added. I have also tried to make the variables consistent across the two Python flavours. I also made minor updates to the docs to reflect these changes.

The only obvious breakage I can think of will be the `casatasks` cabs in `cult-cargo` (I can find no other usage), but I can easily fix that in https://github.com/caracal-pipeline/cult-cargo/pull/137.