### PR TITLE
Add command field to display, fix display when running `build`

### DIFF
--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -254,7 +254,6 @@ def run(parameters: List[str] = [], dump_config: bool = False, dry_run: bool = F
 
     log = logger()
     if not is_logging_boring():
-        display.set_display_style(variant="simple")
         display.enable()
     params = OrderedDict()
     errcode = 0

--- a/stimela/display/display.py
+++ b/stimela/display/display.py
@@ -95,6 +95,9 @@ class Display:
             transient=True
         )
 
+        # Configure a simple, local display as the default.
+        self.set_display_style(variant="simple")
+
     def reset_current_task(self):
         """Calls the reset method of the current DisplayStyle object."""
         self.current_display.reset()

--- a/stimela/display/styles/kube.py
+++ b/stimela/display/styles/kube.py
@@ -184,7 +184,7 @@ class KubeDisplay(DisplayStyle):
             # why the command has square brackets in the first place.
             self.task_command.update(
                 self.task_command_id,
-                value=f"{(task_info.command or '--').strip('[]')}"
+                value=f"{(task_info.command or '--').strip('([])')}"
             )
 
         if extra_info:
@@ -356,7 +356,7 @@ class SimpleKubeDisplay(DisplayStyle):
             # why the command has square brackets in the first place.
             self.task_command.update(
                 self.task_command_id,
-                value=f"{(task_info.command or '--').strip('[]')}"
+                value=f"{(task_info.command or '--').strip('([])')}"
             )
 
         if extra_info:

--- a/stimela/display/styles/local.py
+++ b/stimela/display/styles/local.py
@@ -211,7 +211,7 @@ class LocalDisplay(DisplayStyle):
             # why the command has square brackets in the first place.
             self.task_command.update(
                 self.task_command_id,
-                value=f"{(task_info.command or '--').strip('[]')}"
+                value=f"{(task_info.command or '--').strip('([])')}"
             )
 
         self.task_cpu_usage.update(
@@ -265,6 +265,7 @@ class SimpleLocalDisplay(DisplayStyle):
 
     tracked_values = {
         "task_name": None,
+        "task_command": None,
         "task_status": None,
         "task_cpu_usage": "CPU",
         "task_ram_usage": "RAM",
@@ -297,6 +298,7 @@ class SimpleLocalDisplay(DisplayStyle):
             self.task_elapsed,
             self.task_name,
             self.task_status,
+            self.task_command,
             self.task_cpu_usage,
             self.task_ram_usage,
             self.disk_read,
@@ -343,6 +345,14 @@ class SimpleLocalDisplay(DisplayStyle):
             self.task_status.update(
                 self.task_status_id,
                 value=f"[dim]{task_info.status or 'running'}[/dim]"
+            )
+
+            # Sometimes the command contains square brackets which rich
+            # interprets as formatting. Remove them. # TODO: Figure out
+            # why the command has square brackets in the first place.
+            self.task_command.update(
+                self.task_command_id,
+                value=f"{(task_info.command or '--').strip('([])')}"
             )
 
         self.task_cpu_usage.update(

--- a/stimela/display/styles/slurm.py
+++ b/stimela/display/styles/slurm.py
@@ -107,5 +107,5 @@ class SimpleSlurmDisplay(DisplayStyle):
             # why the command has square brackets in the first place.
             self.task_command.update(
                 self.task_command_id,
-                value=f"{(task_info.command or '--').strip('[]')}"
+                value=f"{(task_info.command or '--').strip('([])')}"
             )


### PR DESCRIPTION
Fixes #482. Fixes #484. 

Very simple set of changes to prevent `stimela build` from breaking and include the command field in the simple local display.

New appearance:
<img width="1177" height="509" alt="image" src="https://github.com/user-attachments/assets/25e2e106-a82e-4171-8902-2987ba452701" />
