### PR TITLE
fix formula-to-formula evaluation marking as unresolved during prevalidation

### DIFF
--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -465,7 +465,7 @@ class Cargo(object):
         if self._dyn_schema:
             # delete implicit parameters, since they may have come from older version of schema
             params = self._delete_implicit_parameters(params, subst)
-            # get rid of unsets
+            # get rid of unset and unresolved parameters
             params = {
                 key: value for key, value in params.items() if value is not UNSET and not isinstance(value, Unresolved)
             }
@@ -481,7 +481,7 @@ class Cargo(object):
                         try:
                             schema = OmegaConf.unsafe_merge(ParameterSchema.copy(), schema)
                         except Exception as exc:
-                            raise SchemaError("error in dynamic schema for parameter 'name'", exc)
+                            raise SchemaError(f"error in dynamic schema for parameter '{name}'", exc)
                         io[name] = Parameter(**schema)
             # new outputs may have been added
             for schema in self.outputs.values():

--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -466,7 +466,9 @@ class Cargo(object):
             # delete implicit parameters, since they may have come from older version of schema
             params = self._delete_implicit_parameters(params, subst)
             # get rid of unsets
-            params = {key: value for key, value in params.items() if value is not UNSET and not isinstance(value, Unresolved) }
+            params = {
+                key: value for key, value in params.items() if value is not UNSET and not isinstance(value, Unresolved)
+            }
             try:
                 self.inputs, self.outputs = self._dyn_schema(params, *self._original_inputs_outputs)
             except Exception:

--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -466,7 +466,7 @@ class Cargo(object):
             # delete implicit parameters, since they may have come from older version of schema
             params = self._delete_implicit_parameters(params, subst)
             # get rid of unsets
-            params = {key: value for key, value in params.items() if value is not UNSET and type(value) is not UNSET}
+            params = {key: value for key, value in params.items() if value is not UNSET and not isinstance(value, Unresolved) }
             try:
                 self.inputs, self.outputs = self._dyn_schema(params, *self._original_inputs_outputs)
             except Exception:

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -882,7 +882,7 @@ class Evaluator(object):
                     except (AttributeError, SubstitutionError, ParserError, FormulaError) as err:
                         if raise_substitution_errors:
                             raise
-                        new_value = Unresolved(errors=[str(err)])
+                        new_value = Unresolved(errors=[err])
                     # if a formula evaluated to a formula string (e.g. because the namespace
                     # contains the raw formula), treat as unresolved
                     if (
@@ -893,7 +893,14 @@ class Evaluator(object):
                         and new_value.startswith("=")
                         and not new_value.startswith("==")
                     ):
-                        new_value = Unresolved(errors=[f"formula '{value}' could not be fully resolved"])
+                        new_value = Unresolved(
+                            errors=[
+                                FormulaError(
+                                    f"{'.'.join(self.location + sublocation)}: "
+                                    f"formula '{value}' could not be fully resolved"
+                                )
+                            ]
+                        )
                     if verbose:
                         print(f"{name}: {value} -> {new_value}")
                     # UNSET return means delete or revert to default

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -883,6 +883,17 @@ class Evaluator(object):
                         if raise_substitution_errors:
                             raise
                         new_value = Unresolved(errors=[str(err)])
+                    # if a formula evaluated to a formula string (e.g. because the namespace
+                    # contains the raw formula), treat as unresolved
+                    if (
+                        not raise_substitution_errors
+                        and type(new_value) is str
+                        and value.startswith("=")
+                        and not value.startswith("==")
+                        and new_value.startswith("=")
+                        and not new_value.startswith("==")
+                    ):
+                        new_value = Unresolved(errors=[f"formula '{value}' could not be fully resolved"])
                     if verbose:
                         print(f"{name}: {value} -> {new_value}")
                     # UNSET return means delete or revert to default

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -865,6 +865,14 @@ class Evaluator(object):
         if collapse_substitution_errors:
             assert subcontainer_type is not None
         params_out = params
+
+        def is_formula_or_subst(value: str) -> bool:
+            return (
+                value.startswith("=")
+                and not value.startswith("==")
+                or (value.startswith("{") and value.endswith("}") and not value.startswith("{{"))
+            )
+
         for name, value in list(params.items()):
             if isinstance(value, Unresolved):
                 continue
@@ -883,30 +891,24 @@ class Evaluator(object):
                         if raise_substitution_errors:
                             raise
                         new_value = Unresolved(errors=[err])
-                    # if a formula evaluated to a formula string (e.g. because the namespace
-                    # contains the raw formula), treat as unresolved
-                    if (
-                        not raise_substitution_errors
-                        and type(new_value) is str
-                        and value.startswith("=")
-                        and not value.startswith("==")
-                        and new_value.startswith("=")
-                        and not new_value.startswith("==")
-                    ):
-                        new_value = Unresolved(
-                            errors=[
-                                FormulaError(
-                                    f"{'.'.join(self.location + sublocation + [name])}: "
-                                    f"formula '{value}' could not be fully resolved"
-                                )
-                            ]
-                        )
                     if verbose:
                         print(f"{name}: {value} -> {new_value}")
+                    # check for circularity
+                    if is_formula_or_subst(value) and new_value == value:
+                        err = SubstitutionError(
+                            f"{'.'.join(self.location + sublocation + [name])}: "
+                            f"self-referencing formula or substitution"
+                        )
+                        if raise_substitution_errors:
+                            raise err
+                        else:
+                            new_value = Unresolved(errors=[err])
                     # UNSET return means delete or revert to default
                     if new_value is UNSET:
                         if subcontainer_type:
-                            raise SubstitutionError(f"{'.'.join(self.location + sublocation)}: UNSET not allowed here")
+                            raise SubstitutionError(
+                                f"{'.'.join(self.location + sublocation + [name])}: UNSET not allowed here"
+                            )
                         if params_out is params:
                             params_out = params.copy()
                         # if value is in defaults and is different, try to evaluate that instead

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -867,9 +867,9 @@ class Evaluator(object):
         params_out = params
 
         def is_formula_or_subst(value: str) -> bool:
-            return ((value.startswith("=") and not value.startswith("=="))
-                or  (value.startswith("{") and value.endswith("}") and not value.startswith("{{")))
-            
+            return (value.startswith("=") and not value.startswith("==")) or (
+                value.startswith("{") and value.endswith("}") and not value.startswith("{{")
+            )
 
         for name, value in list(params.items()):
             if isinstance(value, Unresolved):

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -896,7 +896,7 @@ class Evaluator(object):
                         new_value = Unresolved(
                             errors=[
                                 FormulaError(
-                                    f"{'.'.join(self.location + sublocation)}: "
+                                    f"{'.'.join(self.location + sublocation + [name])}: "
                                     f"formula '{value}' could not be fully resolved"
                                 )
                             ]

--- a/scabha/evaluator.py
+++ b/scabha/evaluator.py
@@ -867,11 +867,9 @@ class Evaluator(object):
         params_out = params
 
         def is_formula_or_subst(value: str) -> bool:
-            return (
-                value.startswith("=")
-                and not value.startswith("==")
-                or (value.startswith("{") and value.endswith("}") and not value.startswith("{{"))
-            )
+            return ((value.startswith("=") and not value.startswith("=="))
+                or  (value.startswith("{") and value.endswith("}") and not value.startswith("{{")))
+            
 
         for name, value in list(params.items()):
             if isinstance(value, Unresolved):

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -815,6 +815,9 @@ class Recipe(Cargo):
         # split parameters into our own, and per-step, and UNSET directives
         params, unset_params = self._preprocess_parameters(params)
 
+        # our own parameters are prevalidated against the outer substitution context;
+        # step parameters are prevalidated against our own subst
+        subst_outer = subst.copy()
         self._update_subst_namespace(subst)
 
         # update assignments
@@ -832,7 +835,7 @@ class Recipe(Cargo):
         # we call this twice, potentially, so define as a function
         def prevalidate_self(params):
             try:
-                params1 = Cargo.prevalidate(self, params, subst=subst, backend=backend)
+                params1 = Cargo.prevalidate(self, params, subst=subst_outer, backend=backend)
                 # mark params that have become unset
                 unset_params.update(set(params) - set(params1))
                 params = params1

--- a/tests/stimela_tests/test_issue527.yml
+++ b/tests/stimela_tests/test_issue527.yml
@@ -5,6 +5,17 @@ cabs:
       msg:
         dtype: str
 
+circular:
+  inputs:
+    circular:
+      default: 0
+
+  steps:
+    s1:
+      cab: echo
+      params: 
+        msg: =current.msg
+
 outer:
   inputs:
     ncpu:
@@ -27,3 +38,5 @@ inner:
       cab: echo
       params:
         msg: =recipe.ncpu
+
+

--- a/tests/stimela_tests/test_issue527.yml
+++ b/tests/stimela_tests/test_issue527.yml
@@ -1,0 +1,29 @@
+cabs:
+  echo:
+    command: echo
+    inputs:
+      msg:
+        dtype: str
+
+outer:
+  inputs:
+    ncpu:
+      dtype: int
+      default: 1
+
+  steps:
+    inner-1:
+      recipe: inner
+      params:
+        ncpu: =recipe.ncpu
+
+inner:
+  inputs:
+    ncpu:
+      dtype: int
+
+  steps:
+    echo-1:
+      cab: echo
+      params:
+        msg: =recipe.ncpu

--- a/tests/stimela_tests/test_recipe.py
+++ b/tests/stimela_tests/test_recipe.py
@@ -122,13 +122,31 @@ def test_test_loop_recipe():
     assert retcode == 0
 
 
-def test_issue527_formula_passing_to_subrecipe():
-    """Test that formula params like =recipe.ncpu are correctly passed to sub-recipes."""
-    print("===== expecting no errors now =====")
+def test_issue527_1():
+    """Test that circular references are ignored in prevalidation"""
+    print("===== expecting no errors =====")
     retcode, output = run("stimela -v -b native run test_issue527.yml outer")
     assert retcode == 0
     print(output)
     assert verify_output(output, "recipe 'outer' executed successfully")
+
+
+def test_issue527_2():
+    """Test that circular references are caught in validation"""
+    print("===== expecting an error =====")
+    retcode, output = run("stimela -v -b native run test_issue527.yml circular")
+    assert retcode == 1
+    print(output)
+    assert verify_output(output, "self-referencing formula or substitution")
+
+
+def test_issue527_3():
+    """Test that circular references are caught in validation"""
+    print("===== expecting an error =====")
+    retcode, output = run("stimela -v -b native run test_issue527.yml circular circular==recipe.circular")
+    assert retcode == 1
+    print(output)
+    assert verify_output(output, "invalid inputs")
 
 
 def test_scatter():

--- a/tests/stimela_tests/test_recipe.py
+++ b/tests/stimela_tests/test_recipe.py
@@ -122,6 +122,15 @@ def test_test_loop_recipe():
     assert retcode == 0
 
 
+def test_issue527_formula_passing_to_subrecipe():
+    """Test that formula params like =recipe.ncpu are correctly passed to sub-recipes."""
+    print("===== expecting no errors now =====")
+    retcode, output = run("stimela -v -b native run test_issue527.yml outer")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "recipe 'outer' executed successfully")
+
+
 def test_scatter():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml basic_loop")


### PR DESCRIPTION
When a sub-recipe receives a formula param like ncpu: =recipe.ncpu, the inner recipe's namespace update replaces subst.recipe with the raw step params (containing the formula string). The evaluator then resolves recipe.ncpu to the formula string itself, which passes through unchanged and fails type validation. Now, formulas that evaluate to formula strings are correctly marked as Unresolved and deferred to runtime.

Fixes #527 and parts of #528