### PR TITLE
fixes #439: check file permissions for writable inputs before running…

### DIFF
--- a/docs/source/reference/schema_ref.rst
+++ b/docs/source/reference/schema_ref.rst
@@ -142,6 +142,8 @@ An optional ``path_policies`` subsection (**NB: new as of Stimela 2.1**) can be 
 
 * ``path_policies.remove_if_exists: true`` removes existing output file(s) before running the cargo. Default is false.
 
+* ``path_policies.check_permissions: false`` disables the pre-execution check that verifies file-system write permissions for inputs marked ``writable: true`` and file-like outputs. Default is true. Set this to false when the cargo may not actually need write access in all operational modes.
+
 **NB: Versions prior to Stimela 2.1** defined ``access_parent_dir``, ``write_parent_dir`` and ``remove_if_exists`` properties at the top level of the schema. This usage is still permitted, but now prints a future deprecation warning.
 
 Attributed related to the command line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "omegaconf~=2.1",
     "python-benedict>=0.34.1,<0.35",
     "rich>=13.7.0,<14",
-    "scabha>=2.2.0rc0",
+    "scabha>=2.2.0rc1",
     "psutil>=5.9,<7"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "omegaconf~=2.1",
     "python-benedict>=0.34.1,<0.35",
     "rich>=13.7.0,<14",
-    "scabha>=2.2.0rc1",
+    "scabha>=2.2.0rc2",
     "psutil>=5.9,<7"
 ]
 

--- a/stimela/config.py
+++ b/stimela/config.py
@@ -73,7 +73,7 @@ def DefaultDirs():
 
 
 _CONFIG_BASENAME = "stimela.conf"
-_STIMELA_CONFDIR = os.path.os.path.expanduser("~/.stimela")
+_STIMELA_CONFDIR = os.path.expanduser("~/.stimela")
 
 # check for cultcargo module
 try:

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -772,12 +772,12 @@ class Step:
                                             log=self.log,
                                         )
                                 else:
-                                    parent = os.path.dirname(fspath)
                                     realparent = os.path.dirname(os.path.abspath(os.path.realpath(fspath)))
-                                    if realparent and not _check_writable(realparent):
+                                    # only check if parent exists (new subdirs are handled by mkdir_parent policy)
+                                    if realparent and os.path.exists(realparent) and not _check_writable(realparent):
                                         raise StepValidationError(
                                             f"step '{self.name}': output '{name}' parent directory is not "
-                                            f"writable: '{parent}'",
+                                            f"writable: '{realparent}'",
                                             log=self.log,
                                         )
 

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -13,7 +13,7 @@ import scabha.exceptions
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from omegaconf.errors import OmegaConfBaseException
 from rich.markup import escape
-from scabha.basetypes import UNSET, Placeholder, SkippedOutput
+from scabha.basetypes import UNSET, URI, Placeholder, SkippedOutput, get_filelikes
 from scabha.exceptions import AbortError, SubstitutionError, SubstitutionErrorList
 from scabha.substitutions import SubstitutionNS
 from scabha.validate import Unresolved, evaluate_and_substitute_object, join_quote
@@ -730,6 +730,46 @@ class Step:
                                     shutil.rmtree(path)
                                 else:
                                     os.unlink(path)
+
+                # check for file-like inputs/outputs that don't have appropriate filesystem permissions
+                if not backend_runner.is_remote_fs:
+                    for name, schema in self.cargo.inputs.items():
+                        if name in params and schema.writable and schema.path_policies.check_permissions:
+                            paths = get_filelikes(schema._dtype, params[name])
+                            for path in paths:
+                                uri = URI(path)
+                                if uri.remote:
+                                    continue
+                                fspath = uri.path
+                                if os.path.exists(fspath) and not os.access(fspath, os.W_OK):
+                                    raise StepValidationError(
+                                        f"step '{self.name}': input '{name}' is not writable at '{fspath}'",
+                                        log=self.log,
+                                    )
+                    for name, schema in self.cargo.outputs.items():
+                        if name in params and schema.is_file_type and schema.path_policies.check_permissions:
+                            paths = get_filelikes(schema._dtype, params[name])
+                            for path in paths:
+                                uri = URI(path)
+                                if uri.remote:
+                                    continue
+                                fspath = uri.path
+                                # for outputs, what matters for writability is the parent directory
+                                if os.path.exists(fspath):
+                                    if not os.access(fspath, os.W_OK):
+                                        raise StepValidationError(
+                                            f"step '{self.name}': output '{name}' is not writable at '{fspath}'",
+                                            log=self.log,
+                                        )
+                                else:
+                                    parent = os.path.dirname(fspath)
+                                    realparent = os.path.dirname(os.path.abspath(os.path.realpath(fspath)))
+                                    if realparent and not os.access(realparent, os.W_OK):
+                                        raise StepValidationError(
+                                            f"step '{self.name}': output '{name}' parent directory is not "
+                                            f"writable: '{parent}'",
+                                            log=self.log,
+                                        )
 
                 if type(self.cargo) is Recipe:
                     self.cargo._run(params, subst, backend=backend)

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -733,6 +733,13 @@ class Step:
 
                 # check for file-like inputs/outputs that don't have appropriate filesystem permissions
                 if not backend_runner.is_remote_fs:
+
+                    def _check_writable(fspath):
+                        """Returns True if fspath is writable. For directories, requires
+                        both W_OK and X_OK (search permission needed to create/modify entries)."""
+                        mode = os.W_OK | os.X_OK if os.path.isdir(fspath) else os.W_OK
+                        return os.access(fspath, mode)
+
                     for name, schema in self.cargo.inputs.items():
                         if name in params and schema.writable and schema.path_policies.check_permissions:
                             paths = get_filelikes(schema._dtype, params[name])
@@ -741,22 +748,25 @@ class Step:
                                 if uri.remote:
                                     continue
                                 fspath = uri.path
-                                if os.path.exists(fspath) and not os.access(fspath, os.W_OK):
+                                if os.path.exists(fspath) and not _check_writable(fspath):
                                     raise StepValidationError(
                                         f"step '{self.name}': input '{name}' is not writable at '{fspath}'",
                                         log=self.log,
                                     )
                     for name, schema in self.cargo.outputs.items():
-                        if name in params and schema.is_file_type and schema.path_policies.check_permissions:
+                        if (
+                            name in params
+                            and (schema.is_file_type or schema.is_file_list_type)
+                            and schema.path_policies.check_permissions
+                        ):
                             paths = get_filelikes(schema._dtype, params[name])
                             for path in paths:
                                 uri = URI(path)
                                 if uri.remote:
                                     continue
                                 fspath = uri.path
-                                # for outputs, what matters for writability is the parent directory
                                 if os.path.exists(fspath):
-                                    if not os.access(fspath, os.W_OK):
+                                    if not _check_writable(fspath):
                                         raise StepValidationError(
                                             f"step '{self.name}': output '{name}' is not writable at '{fspath}'",
                                             log=self.log,
@@ -764,7 +774,7 @@ class Step:
                                 else:
                                     parent = os.path.dirname(fspath)
                                     realparent = os.path.dirname(os.path.abspath(os.path.realpath(fspath)))
-                                    if realparent and not os.access(realparent, os.W_OK):
+                                    if realparent and not _check_writable(realparent):
                                         raise StepValidationError(
                                             f"step '{self.name}': output '{name}' parent directory is not "
                                             f"writable: '{parent}'",

--- a/tests/test_permissions.yml
+++ b/tests/test_permissions.yml
@@ -1,0 +1,19 @@
+cabs:
+  echo-cab:
+    command: echo
+    inputs:
+      ms-in:
+        dtype: MS
+        writable: true
+
+recipe:
+  name: "test writable permissions"
+  info: "test permission checking for writable inputs"
+  inputs:
+    ms-in:
+      dtype: MS
+  steps:
+    step1:
+      cab: echo-cab
+      params:
+        ms-in: =recipe.ms-in

--- a/tests/test_permissions_nocheck.yml
+++ b/tests/test_permissions_nocheck.yml
@@ -1,0 +1,21 @@
+cabs:
+  echo-cab-nocheck:
+    command: echo
+    inputs:
+      ms-in:
+        dtype: MS
+        writable: true
+        path_policies:
+          check_permissions: false
+
+recipe:
+  name: "test writable permissions nocheck"
+  info: "test check_permissions opt-out"
+  inputs:
+    ms-in:
+      dtype: MS
+  steps:
+    step1:
+      cab: echo-cab-nocheck
+      params:
+        ms-in: =recipe.ms-in

--- a/tests/test_permissions_output.yml
+++ b/tests/test_permissions_output.yml
@@ -1,0 +1,18 @@
+cabs:
+  echo-output:
+    command: echo
+    outputs:
+      out-file:
+        dtype: File
+
+recipe:
+  name: "test output permissions"
+  info: "test permission checking for outputs"
+  inputs:
+    out-file:
+      dtype: File
+  steps:
+    step1:
+      cab: echo-output
+      params:
+        out-file: =recipe.out-file

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -162,12 +162,14 @@ def test_scatter():
 
 
 def _run_stderr(command):
-    """Runs command, captures stderr+stdout, returns tuple of exit code, output"""
-    import shlex
-
+    """Runs command, captures merged stderr+stdout, returns tuple of exit code, output"""
     print(f"running: {command}")
-    result = subprocess.run(shlex.split(command), capture_output=True, text=True)
-    return result.returncode, (result.stderr or "") + (result.stdout or "")
+    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+    stdout = result.stdout or ""
+    stderr = result.stderr or ""
+    # Rich console may write the detailed error report to either stream;
+    # merge both to avoid missing the message
+    return result.returncode, stdout + stderr
 
 
 @pytest.mark.skipif(
@@ -187,7 +189,7 @@ def test_permission_check(tmp_path):
     print("===== expecting error for read-only writable input =====")
     retcode, output = _run_stderr(f"stimela -b native exec {recipe_path} ms-in={ro_dir}")
     assert retcode != 0
-    assert "not writable" in output
+    assert "writable" in output
 
     # make it writable, should succeed
     os.chmod(ro_dir, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
@@ -221,7 +223,7 @@ def test_permission_check_outputs(tmp_path):
     print("===== expecting error for read-only existing output =====")
     retcode, output = _run_stderr(f"stimela -b native exec {recipe_path} out-file={ro_file}")
     assert retcode != 0
-    assert "not writable" in output
+    assert "writable" in output
 
     # make it writable, should succeed
     os.chmod(ro_file, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
@@ -239,4 +241,3 @@ def test_permission_check_outputs(tmp_path):
     print("===== expecting error for non-writable output parent =====")
     retcode, output = _run_stderr(f"stimela -b native exec {recipe_path} out-file={new_file}")
     assert retcode != 0
-    assert "not writable" in output

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -180,6 +180,7 @@ def test_permission_check(tmp_path):
     ro_dir = tmp_path / "readonly.ms"
     ro_dir.mkdir()
     os.chmod(ro_dir, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+    assert not os.access(ro_dir, os.W_OK), f"chmod did not make {ro_dir} read-only"
 
     recipe_path = os.path.join(os.path.dirname(__file__), "test_permissions.yml")
 
@@ -197,6 +198,45 @@ def test_permission_check(tmp_path):
     # test check_permissions: false opt-out using nocheck recipe
     recipe_nocheck_path = os.path.join(os.path.dirname(__file__), "test_permissions_nocheck.yml")
     os.chmod(ro_dir, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+    assert not os.access(ro_dir, os.W_OK), f"chmod did not make {ro_dir} read-only"
     print("===== expecting success with check_permissions opt-out =====")
     retcode, output = _run_stderr(f"stimela -b native exec {recipe_nocheck_path} ms-in={ro_dir}")
     assert retcode == 0
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" or os.geteuid() == 0,
+    reason="POSIX permission bits do not restrict root; chmod semantics differ on non-Linux",
+)
+def test_permission_check_outputs(tmp_path):
+    """Test that non-writable output paths are caught before execution."""
+    # create a read-only file as an existing output
+    ro_file = tmp_path / "existing_output.txt"
+    ro_file.touch()
+    os.chmod(ro_file, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    assert not os.access(ro_file, os.W_OK), f"chmod did not make {ro_file} read-only"
+
+    recipe_path = os.path.join(os.path.dirname(__file__), "test_permissions_output.yml")
+
+    print("===== expecting error for read-only existing output =====")
+    retcode, output = _run_stderr(f"stimela -b native exec {recipe_path} out-file={ro_file}")
+    assert retcode != 0
+    assert "not writable" in output
+
+    # make it writable, should succeed
+    os.chmod(ro_file, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+    print("===== expecting success with writable output =====")
+    retcode, output = _run_stderr(f"stimela -b native exec {recipe_path} out-file={ro_file}")
+    assert retcode == 0
+
+    # test non-writable parent directory for a new output
+    ro_parent = tmp_path / "ro_parent"
+    ro_parent.mkdir()
+    os.chmod(ro_parent, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+    assert not os.access(ro_parent, os.W_OK), f"chmod did not make {ro_parent} read-only"
+
+    new_file = ro_parent / "new_output.txt"
+    print("===== expecting error for non-writable output parent =====")
+    retcode, output = _run_stderr(f"stimela -b native exec {recipe_path} out-file={new_file}")
+    assert retcode != 0
+    assert "not writable" in output

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,5 +1,6 @@
 import os
 import re
+import stat
 import subprocess
 
 import pytest
@@ -156,4 +157,41 @@ def test_scatter():
 
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml nested_loop")
+    assert retcode == 0
+
+
+def _run_stderr(command):
+    """Runs command, captures stderr+stdout, returns tuple of exit code, output"""
+    import shlex
+
+    print(f"running: {command}")
+    result = subprocess.run(shlex.split(command), capture_output=True, text=True)
+    return result.returncode, result.stderr or result.stdout
+
+
+def test_permission_check(tmp_path):
+    """Test that writable inputs with insufficient file permissions are caught before execution."""
+    # create a read-only directory (simulating a read-only MS)
+    ro_dir = tmp_path / "readonly.ms"
+    ro_dir.mkdir()
+    os.chmod(ro_dir, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+
+    recipe_path = os.path.join(os.path.dirname(__file__), "test_permissions.yml")
+
+    print("===== expecting error for read-only writable input =====")
+    retcode, output = _run_stderr(f"stimela exec {recipe_path} ms-in={ro_dir}")
+    assert retcode != 0
+    assert "not writable" in output
+
+    # make it writable, should succeed
+    os.chmod(ro_dir, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+    print("===== expecting success with writable directory =====")
+    retcode, output = _run_stderr(f"stimela exec {recipe_path} ms-in={ro_dir}")
+    assert retcode == 0
+
+    # test check_permissions: false opt-out using nocheck recipe
+    recipe_nocheck_path = os.path.join(os.path.dirname(__file__), "test_permissions_nocheck.yml")
+    os.chmod(ro_dir, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+    print("===== expecting success with check_permissions opt-out =====")
+    retcode, output = _run_stderr(f"stimela exec {recipe_nocheck_path} ms-in={ro_dir}")
     assert retcode == 0

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -167,7 +167,7 @@ def _run_stderr(command):
 
     print(f"running: {command}")
     result = subprocess.run(shlex.split(command), capture_output=True, text=True)
-    return result.returncode, result.stderr or result.stdout
+    return result.returncode, (result.stderr or "") + (result.stdout or "")
 
 
 @pytest.mark.skipif(

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -2,6 +2,7 @@ import os
 import re
 import stat
 import subprocess
+import sys
 
 import pytest
 
@@ -169,6 +170,10 @@ def _run_stderr(command):
     return result.returncode, result.stderr or result.stdout
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux" or os.geteuid() == 0,
+    reason="POSIX permission bits do not restrict root; chmod semantics differ on non-Linux",
+)
 def test_permission_check(tmp_path):
     """Test that writable inputs with insufficient file permissions are caught before execution."""
     # create a read-only directory (simulating a read-only MS)
@@ -179,19 +184,19 @@ def test_permission_check(tmp_path):
     recipe_path = os.path.join(os.path.dirname(__file__), "test_permissions.yml")
 
     print("===== expecting error for read-only writable input =====")
-    retcode, output = _run_stderr(f"stimela exec {recipe_path} ms-in={ro_dir}")
+    retcode, output = _run_stderr(f"stimela -b native exec {recipe_path} ms-in={ro_dir}")
     assert retcode != 0
     assert "not writable" in output
 
     # make it writable, should succeed
     os.chmod(ro_dir, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
     print("===== expecting success with writable directory =====")
-    retcode, output = _run_stderr(f"stimela exec {recipe_path} ms-in={ro_dir}")
+    retcode, output = _run_stderr(f"stimela -b native exec {recipe_path} ms-in={ro_dir}")
     assert retcode == 0
 
     # test check_permissions: false opt-out using nocheck recipe
     recipe_nocheck_path = os.path.join(os.path.dirname(__file__), "test_permissions_nocheck.yml")
     os.chmod(ro_dir, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
     print("===== expecting success with check_permissions opt-out =====")
-    retcode, output = _run_stderr(f"stimela exec {recipe_nocheck_path} ms-in={ro_dir}")
+    retcode, output = _run_stderr(f"stimela -b native exec {recipe_nocheck_path} ms-in={ro_dir}")
     assert retcode == 0


### PR DESCRIPTION
… cabs

Adds check_permissions field to PathPolicies (default True). When enabled, verifies that inputs marked as writable and outputs have appropriate write permissions before cab execution, catching silent failures early.