### PR TITLE
Abbreviate long inputs in python flavour cab display

### DIFF
--- a/stimela/backends/flavours/python_flavours.py
+++ b/stimela/backends/flavours/python_flavours.py
@@ -24,6 +24,29 @@ from . import _BaseFlavour, _CallableFlavour
 CAB_OUTPUT_PREFIX = "### YIELDING CAB OUTPUT ## "
 
 
+def _abbreviate_repr(value, max_str_len=80, max_collection_items=5):
+    """Return an abbreviated repr of a value for display purposes.
+
+    Truncates strings longer than max_str_len and collections with more
+    than max_collection_items elements. Only affects display output, not
+    the actual values passed to functions.
+    """
+    if isinstance(value, str):
+        if len(value) > max_str_len:
+            return repr(value[:max_str_len] + "...")
+    elif isinstance(value, (list, tuple)):
+        if len(value) > max_collection_items:
+            items = ", ".join(repr(v) for v in value[:max_collection_items])
+            bracket_open = "[" if isinstance(value, list) else "("
+            bracket_close = "]" if isinstance(value, list) else ")"
+            return f"{bracket_open}{items}, ...{len(value) - max_collection_items} more{bracket_close}"
+    elif isinstance(value, dict):
+        if len(value) > max_collection_items:
+            items = ", ".join(f"{repr(k)}: {repr(v)}" for k, v in list(value.items())[:max_collection_items])
+            return "{" + f"{items}, ...{len(value) - max_collection_items} more" + "}"
+    return repr(value)
+
+
 def form_python_function_call(function: str, cab: Cab, params: Dict[str, Any]):
     """
     Helper. Converts a function name and a list of parameters into a string
@@ -40,7 +63,7 @@ def form_python_function_call(function: str, cab: Cab, params: Dict[str, Any]):
     """
     arguments = []
     for key, value in cab.filter_input_params(params).items():
-        arguments.append(f"{key}={repr(value)}")
+        arguments.append(f"{key}={_abbreviate_repr(value)}")
     return f"{function}({', '.join(arguments)})"
 
 
@@ -54,7 +77,7 @@ def format_dict_as_function_call(func_name: Optional[str], d: Dict[str, Any], in
         comma = ""
     pad = " " * indent
     for k, v in d.items():
-        lines.append(f"{pad}{k}={repr(v)}{comma}")
+        lines.append(f"{pad}{k}={_abbreviate_repr(v)}{comma}")
     # strip trailing comma
     if func_name:
         lines[-1] = lines[-1][:-1] + ")"

--- a/stimela/backends/flavours/python_flavours.py
+++ b/stimela/backends/flavours/python_flavours.py
@@ -1,4 +1,5 @@
 import base64
+import itertools
 import json
 import logging
 import os.path
@@ -35,23 +36,35 @@ def _abbreviate_repr(value, max_str_len=80, max_collection_items=5):
         if len(value) > max_str_len:
             return repr(value[:max_str_len] + "...")
     elif isinstance(value, (list, tuple)):
+        bracket_open = "[" if isinstance(value, list) else "("
+        bracket_close = "]" if isinstance(value, list) else ")"
         if len(value) > max_collection_items:
-            items = ", ".join(repr(v) for v in value[:max_collection_items])
-            bracket_open = "[" if isinstance(value, list) else "("
-            bracket_close = "]" if isinstance(value, list) else ")"
+            abbreviated = (_abbreviate_repr(v, max_str_len, max_collection_items) for v in value[:max_collection_items])
+            items = ", ".join(abbreviated)
             return f"{bracket_open}{items}, ...{len(value) - max_collection_items} more{bracket_close}"
+        else:
+            items = ", ".join(_abbreviate_repr(v, max_str_len, max_collection_items) for v in value)
+            return f"{bracket_open}{items}{bracket_close}"
     elif isinstance(value, dict):
         if len(value) > max_collection_items:
-            items = ", ".join(f"{repr(k)}: {repr(v)}" for k, v in list(value.items())[:max_collection_items])
+            items = ", ".join(
+                f"{repr(k)}: {_abbreviate_repr(v, max_str_len, max_collection_items)}"
+                for k, v in itertools.islice(value.items(), max_collection_items)
+            )
             return "{" + f"{items}, ...{len(value) - max_collection_items} more" + "}"
+        else:
+            items = ", ".join(
+                f"{repr(k)}: {_abbreviate_repr(v, max_str_len, max_collection_items)}" for k, v in value.items()
+            )
+            return "{" + items + "}"
     return repr(value)
 
 
 def form_python_function_call(function: str, cab: Cab, params: Dict[str, Any]):
     """
-    Helper. Converts a function name and a list of parameters into a string
-    representation of a Python function call that can be parsed by the interpreter.
-    Uses the cab schema info and policies to decide which parametets to include.
+    Helper. Converts a function name and a list of parameters into an abbreviated
+    string representation of a Python function call for display/logging only.
+    Uses the cab schema info and policies to decide which parameters to include.
 
     Args:
         function (str) function name

--- a/tests/test_abbreviate_repr.py
+++ b/tests/test_abbreviate_repr.py
@@ -1,0 +1,82 @@
+"""Tests for _abbreviate_repr in python_flavours."""
+
+from stimela.backends.flavours.python_flavours import _abbreviate_repr
+
+
+class TestAbbreviateRepr:
+    """Tests for _abbreviate_repr."""
+
+    def test_short_string_unchanged(self):
+        assert _abbreviate_repr("hello") == "'hello'"
+
+    def test_long_string_truncated(self):
+        long_str = "a" * 100
+        result = _abbreviate_repr(long_str, max_str_len=10)
+        assert result == repr("a" * 10 + "...")
+
+    def test_string_at_max_len_unchanged(self):
+        s = "a" * 80
+        result = _abbreviate_repr(s, max_str_len=80)
+        assert result == repr(s)
+
+    def test_short_list_unchanged(self):
+        result = _abbreviate_repr([1, 2, 3])
+        assert result == "[1, 2, 3]"
+
+    def test_long_list_truncated(self):
+        result = _abbreviate_repr(list(range(10)), max_collection_items=3)
+        assert result == "[0, 1, 2, ...7 more]"
+
+    def test_short_tuple_unchanged(self):
+        result = _abbreviate_repr((1, 2))
+        assert result == "(1, 2)"
+
+    def test_long_tuple_truncated(self):
+        result = _abbreviate_repr(tuple(range(8)), max_collection_items=3)
+        assert result == "(0, 1, 2, ...5 more)"
+
+    def test_short_dict_unchanged(self):
+        result = _abbreviate_repr({"a": 1})
+        assert result == "{'a': 1}"
+
+    def test_long_dict_truncated(self):
+        d = {f"k{i}": i for i in range(10)}
+        result = _abbreviate_repr(d, max_collection_items=2)
+        assert result.startswith("{")
+        assert result.endswith("...8 more}")
+        assert "'k0': 0" in result
+        assert "'k1': 1" in result
+
+    def test_nested_list_elements_abbreviated(self):
+        """Nested structures in lists should also be abbreviated."""
+        nested = ["a" * 200, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
+        result = _abbreviate_repr(nested, max_str_len=10, max_collection_items=5)
+        # The long string element should be truncated
+        assert "..." in result
+        assert "a" * 200 not in result
+
+    def test_nested_dict_values_abbreviated(self):
+        """Nested values in dicts should also be abbreviated."""
+        d = {"key": "b" * 200}
+        result = _abbreviate_repr(d, max_str_len=10)
+        # The long string value should be truncated
+        assert "b" * 200 not in result
+
+    def test_int_unchanged(self):
+        assert _abbreviate_repr(42) == "42"
+
+    def test_none_unchanged(self):
+        assert _abbreviate_repr(None) == "None"
+
+    def test_bool_unchanged(self):
+        assert _abbreviate_repr(True) == "True"
+
+    def test_list_at_max_items_unchanged(self):
+        result = _abbreviate_repr([1, 2, 3], max_collection_items=3)
+        assert result == "[1, 2, 3]"
+
+    def test_dict_does_not_materialize_full_items(self):
+        """Large dict should not build a full items list."""
+        large_dict = {f"k{i}": i for i in range(1000)}
+        result = _abbreviate_repr(large_dict, max_collection_items=2)
+        assert "...998 more" in result


### PR DESCRIPTION
## Summary
- Add `_abbreviate_repr()` helper that truncates long values for display: strings >80 chars are truncated with "...", lists/tuples >5 elements show first 5 + count of remaining, dicts >5 keys likewise
- Use it in `form_python_function_call()` and `format_dict_as_function_call()` instead of bare `repr()`
- Only affects log/display output -- actual values passed to functions are unchanged
- Benefits all three call sites: Python callable flavour, Python code flavour, and CASA task flavour

Fixes #411

## Test plan
- [ ] Verify that long string arguments are truncated in log output
- [ ] Verify that large list/dict arguments are abbreviated in log output
- [ ] Verify that short/small arguments are displayed unchanged
- [ ] Confirm actual function arguments are not affected (they go through separate JSON/base64 encoding)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>