### PR TITLE
Implicitly select output for single-output Python callable cabs

### DIFF
--- a/stimela/backends/flavours/__init__.py
+++ b/stimela/backends/flavours/__init__.py
@@ -68,7 +68,7 @@ class _CallableFlavour(_BaseFlavour):
         if self.output_dict and self.output:
             raise CabValidationError(f"cab {cab.name}: can't specify both 'output_dict' and 'output'")
         if self.output and self.output not in cab.outputs:
-            raise CabValidationError(f"cab {cab.name}: flavour.outputs='{self.outputs}' is not a known output")
+            raise CabValidationError(f"cab {cab.name}: flavour.output='{self.output}' is not a known output")
         # if output is not explicitly set and output_dict is not used, implicitly
         # select the output when there is exactly one non-implicit, non-named output
         if self.output is None and not self.output_dict:

--- a/stimela/backends/flavours/__init__.py
+++ b/stimela/backends/flavours/__init__.py
@@ -69,6 +69,14 @@ class _CallableFlavour(_BaseFlavour):
             raise CabValidationError(f"cab {cab.name}: can't specify both 'output_dict' and 'output'")
         if self.output and self.output not in cab.outputs:
             raise CabValidationError(f"cab {cab.name}: flavour.outputs='{self.outputs}' is not a known output")
+        # if output is not explicitly set and output_dict is not used, implicitly
+        # select the output when there is exactly one non-implicit, non-named output
+        if self.output is None and not self.output_dict:
+            regular_outputs = [
+                name for name, schema in cab.outputs.items() if not schema.is_named_output and not schema.implicit
+            ]
+            if len(regular_outputs) == 1:
+                self.output = regular_outputs[0]
 
 
 _flavour_map = None

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -18,3 +18,73 @@ def test_wrangler_replace_suppress():
     assert retcode == 0
     print(output)
     assert verify_output(output, "y = 46barbar")
+    # verify that step s6_implicit (implicit output, no flavour.output specified) produced x = 14
+    assert verify_output(output, "s6_implicit.*x = 14")
+
+
+def test_implicit_output_single():
+    """When a python callable has exactly one output and flavour.output is not set,
+    the output should be implicitly selected."""
+    from collections import OrderedDict
+    from unittest.mock import MagicMock
+
+    from scabha.cargo import Parameter
+
+    from stimela.backends.flavours import _CallableFlavour
+
+    flavour = _CallableFlavour()
+    cab = MagicMock()
+    cab.name = "test_cab"
+    cab.outputs = OrderedDict({"x": Parameter(dtype="int")})
+    flavour.finalize(cab)
+    assert flavour.output == "x"
+
+
+def test_explicit_output_still_works():
+    """When flavour.output is explicitly set, it should be used as-is."""
+    from collections import OrderedDict
+    from unittest.mock import MagicMock
+
+    from scabha.cargo import Parameter
+
+    from stimela.backends.flavours import _CallableFlavour
+
+    flavour = _CallableFlavour(output="x")
+    cab = MagicMock()
+    cab.name = "test_cab"
+    cab.outputs = OrderedDict({"x": Parameter(dtype="int"), "y": Parameter(dtype="str")})
+    flavour.finalize(cab)
+    assert flavour.output == "x"
+
+
+def test_no_implicit_output_multiple():
+    """When a python callable has multiple outputs and flavour.output is not set,
+    the output should NOT be implicitly selected (remains None)."""
+    from collections import OrderedDict
+    from unittest.mock import MagicMock
+
+    from scabha.cargo import Parameter
+
+    from stimela.backends.flavours import _CallableFlavour
+
+    flavour = _CallableFlavour()
+    cab = MagicMock()
+    cab.name = "test_cab"
+    cab.outputs = OrderedDict({"x": Parameter(dtype="int"), "y": Parameter(dtype="str")})
+    flavour.finalize(cab)
+    assert flavour.output is None
+
+
+def test_no_implicit_output_zero():
+    """When a python callable has no outputs, flavour.output should remain None."""
+    from collections import OrderedDict
+    from unittest.mock import MagicMock
+
+    from stimela.backends.flavours import _CallableFlavour
+
+    flavour = _CallableFlavour()
+    cab = MagicMock()
+    cab.name = "test_cab"
+    cab.outputs = OrderedDict()
+    flavour.finalize(cab)
+    assert flavour.output is None

--- a/tests/test_callables.yml
+++ b/tests/test_callables.yml
@@ -45,6 +45,20 @@ cabs:
       y: 
         dtype: str
 
+  test_callable_implicit_output:
+    command: tests.test_callables.callable_function
+    flavour:
+      kind: python
+      # output is NOT specified -- should be implicitly selected since there's only one
+    inputs:
+      a:
+        dtype: int
+      b:
+        dtype: str
+    outputs:
+      x:
+        dtype: int
+
   test_callable4:
     command: |
       print("a is {current.a} and b is {current.b}")
@@ -111,3 +125,8 @@ test_callables:
       params:
         a: =previous.x
         b: =previous.y
+    s6_implicit:
+      cab: test_callable_implicit_output
+      params:
+        a: 7
+        b: "baz"


### PR DESCRIPTION
## Summary
- When a Python callable cab has exactly one output and `flavour.output` is not specified, automatically use that output as the return value destination
- This eliminates the need to redundantly specify `flavour.output` in the common single-output case, as described in #366
- Explicit `flavour.output` and `output_dict` settings continue to work as before

## Test plan
- [x] Unit test: single output without `flavour.output` -> auto-selected
- [x] Unit test: explicit `flavour.output` with multiple outputs -> respected
- [x] Unit test: multiple outputs without `flavour.output` -> remains None (no implicit selection)
- [x] Unit test: zero outputs -> remains None
- [x] Integration test: new step `s6_implicit` in `test_callables.yml` verifies end-to-end implicit output routing

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)