### PR TITLE
Support (filename.py)function syntax for callables

### DIFF
--- a/stimela/backends/flavours/python_flavours.py
+++ b/stimela/backends/flavours/python_flavours.py
@@ -18,6 +18,7 @@ from stimela.backends import resolve_image_name
 from stimela.exceptions import CabValidationError
 from stimela.kitchen import wranglers
 from stimela.kitchen.cab import Cab
+from stimela.kitchen.utils import parse_file_callable, resolve_file_path
 
 from . import _BaseFlavour, _CallableFlavour
 
@@ -146,10 +147,20 @@ class PythonCallableFlavour(_CallableFlavour):
             except Exception as exc:
                 raise SubstitutionError(f"error substituting Python callable '{cab.command}'", exc)
 
-        if "." in command:
-            py_module, py_function = cab.command.rsplit(".", 1)
+        # check for (path/file.py)function syntax
+        file_callable = parse_file_callable(command)
+        if file_callable:
+            py_file_path, py_function = file_callable
+            py_file_path = resolve_file_path(py_file_path)
+            py_module = None
+        elif "." in command:
+            py_module, py_function = command.rsplit(".", 1)
+            py_file_path = None
         else:
-            raise CabValidationError(f"cab {cab.name}: python flavour requires a command of the form module.function")
+            raise CabValidationError(
+                f"cab {cab.name}: python flavour requires a command of the form "
+                f"module.function or (path/file.py)function"
+            )
         self.command_name = py_function
 
         # convert inputs into a JSON string
@@ -165,7 +176,10 @@ class PythonCallableFlavour(_CallableFlavour):
 
         # form up command string
         if stimela.VERBOSE:
-            msg1 = f"print('## importing {py_module}.{py_function}')"
+            if py_file_path:
+                msg1 = f"print('## loading {py_function} from {py_file_path}')"
+            else:
+                msg1 = f"print('## importing {py_module}.{py_function}')"
             msg2 = (
                 f"print(f'## invoking callable {command}({{repr(_inputs)}}) "
                 f"(as click command) using external interpreter')"
@@ -182,6 +196,16 @@ class PythonCallableFlavour(_CallableFlavour):
         if self.post_commands:
             post_command_str += "\n".join(self.post_commands.values())
 
+        # generate import code based on syntax
+        if py_file_path:
+            import_code = f"""import importlib.util as _ilu
+_spec = _ilu.spec_from_file_location("{py_function}_module", "{py_file_path}")
+_mod = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+{py_function} = getattr(_mod, "{py_function}")"""
+        else:
+            import_code = f"from {py_module} import {py_function}"
+
         code = f"""
 import sys, json, zlib, base64
 _inputs = json.loads(zlib.decompress(
@@ -190,7 +214,7 @@ _inputs = json.loads(zlib.decompress(
 sys.path.append('.')
 {pre_command_str}
 {msg1}
-from {py_module} import {py_function}
+{import_code}
 try:
     from click import Command
 except ImportError:

--- a/stimela/backends/flavours/python_flavours.py
+++ b/stimela/backends/flavours/python_flavours.py
@@ -151,7 +151,7 @@ class PythonCallableFlavour(_CallableFlavour):
         file_callable = parse_file_callable(command)
         if file_callable:
             py_file_path, py_function = file_callable
-            py_file_path = resolve_file_path(py_file_path)
+            py_file_path = resolve_file_path(py_file_path, yaml_dir=getattr(cab, "yaml_dir", None))
             py_module = None
         elif "." in command:
             py_module, py_function = command.rsplit(".", 1)
@@ -199,7 +199,7 @@ class PythonCallableFlavour(_CallableFlavour):
         # generate import code based on syntax
         if py_file_path:
             import_code = f"""import importlib.util as _ilu
-_spec = _ilu.spec_from_file_location("{py_function}_module", "{py_file_path}")
+_spec = _ilu.spec_from_file_location("{py_function}_module", {repr(py_file_path)})
 _mod = _ilu.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 {py_function} = getattr(_mod, "{py_function}")"""

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -20,6 +20,7 @@ from stimela.backends import StimelaBackendSchema, flavours
 from stimela.exceptions import CabValidationError, StimelaBaseImageError, StimelaCabRuntimeError
 
 from . import wranglers
+from .utils import parse_file_callable, resolve_callable
 
 ParameterPassingMechanism = Enum("ParameterPassingMechanism", "args yaml", module=__name__)
 
@@ -119,7 +120,27 @@ class Cab(Cargo):
     policies: ParameterPolicies = EmptyClassDefault(ParameterPolicies)
 
     def __post_init__(self):
+        # Intercept (path/file.py)function syntax for dynamic_schema before
+        # Cargo.__post_init__ tries to resolve it via importlib.import_module.
+        # We temporarily set dynamic_schema to None so the parent skips its
+        # resolution, then handle it ourselves afterward.
+        file_based_dynschema = None
+        if self.dynamic_schema is not None and parse_file_callable(self.dynamic_schema):
+            file_based_dynschema = self.dynamic_schema
+            self.dynamic_schema = None
+
         Cargo.__post_init__(self)
+
+        # Now resolve file-based dynamic schema if needed
+        if file_based_dynschema is not None:
+            self.dynamic_schema = file_based_dynschema
+            try:
+                self._dyn_schema = resolve_callable(file_based_dynschema)
+            except Exception as exc:
+                raise CabValidationError(f"can't load dynamic schema '{file_based_dynschema}': {exc}")
+            # make backup copy of original inputs/outputs (same as Cargo does)
+            self._original_inputs_outputs = self.inputs.copy(), self.outputs.copy()
+
         for param in self.inputs.keys():
             if param in self.outputs:
                 raise CabValidationError(f"cab {self.name}: parameter '{param}' appears in both inputs and outputs")

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -119,6 +119,9 @@ class Cab(Cargo):
     # default parameter conversion policies
     policies: ParameterPolicies = EmptyClassDefault(ParameterPolicies)
 
+    # directory of the YAML file that defined this cab (for resolving relative paths)
+    yaml_dir: Optional[str] = None
+
     def __post_init__(self):
         # Intercept (path/file.py)function syntax for dynamic_schema before
         # Cargo.__post_init__ tries to resolve it via importlib.import_module.
@@ -135,9 +138,9 @@ class Cab(Cargo):
         if file_based_dynschema is not None:
             self.dynamic_schema = file_based_dynschema
             try:
-                self._dyn_schema = resolve_callable(file_based_dynschema)
+                self._dyn_schema = resolve_callable(file_based_dynschema, yaml_dir=self.yaml_dir)
             except Exception as exc:
-                raise CabValidationError(f"can't load dynamic schema '{file_based_dynschema}': {exc}")
+                raise CabValidationError(f"can't load dynamic schema '{file_based_dynschema}': {exc}") from exc
             # make backup copy of original inputs/outputs (same as Cargo does)
             self._original_inputs_outputs = self.inputs.copy(), self.outputs.copy()
 

--- a/stimela/kitchen/utils.py
+++ b/stimela/kitchen/utils.py
@@ -1,0 +1,109 @@
+"""Utility functions for the kitchen module."""
+
+import importlib
+import importlib.util
+import os
+import re
+from typing import Callable, Optional, Tuple
+
+# Regex to match (path/to/file.py)function or (path/to/file.py)/function
+_FILE_CALLABLE_RE = re.compile(r"^\((.+\.py)\)/?(\w+)$")
+
+
+def parse_file_callable(spec: str) -> Optional[Tuple[str, str]]:
+    """Parse a callable reference in (path/to/file.py)function syntax.
+
+    Returns (file_path, function_name) if the spec matches the pattern,
+    or None if it doesn't match.
+    """
+    match = _FILE_CALLABLE_RE.match(spec)
+    if match:
+        return match.group(1), match.group(2)
+    return None
+
+
+def resolve_file_path(file_path: str, yaml_dir: Optional[str] = None) -> str:
+    """Resolve a file path, handling ./ prefix as relative to yaml_dir.
+
+    A path starting with ./ is interpreted relative to the directory of the
+    YAML file where it appears. Other paths are interpreted relative to CWD.
+
+    Args:
+        file_path: The path from the callable spec.
+        yaml_dir: The directory of the YAML file, or None.
+
+    Returns:
+        Absolute path to the file.
+    """
+    if file_path.startswith("./") or file_path.startswith("../"):
+        if yaml_dir:
+            file_path = os.path.join(yaml_dir, file_path)
+    return os.path.abspath(file_path)
+
+
+def load_callable_from_file(file_path: str, func_name: str) -> Callable:
+    """Load a callable from a Python file using importlib.
+
+    Args:
+        file_path: Absolute path to the Python file.
+        func_name: Name of the function to load.
+
+    Returns:
+        The callable object.
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist.
+        ImportError: If the module can't be loaded.
+        AttributeError: If the function doesn't exist in the module.
+        TypeError: If the attribute is not callable.
+    """
+    if not os.path.isfile(file_path):
+        raise FileNotFoundError(f"Python file not found: {file_path}")
+
+    module_name = os.path.splitext(os.path.basename(file_path))[0]
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"can't create module spec from {file_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    func = getattr(module, func_name, None)
+    if func is None:
+        raise AttributeError(f"{func_name} not found in {file_path}")
+    if not callable(func):
+        raise TypeError(f"{func_name} in {file_path} is not callable")
+
+    return func
+
+
+def resolve_callable(spec: str, yaml_dir: Optional[str] = None) -> Callable:
+    """Resolve a callable from either (path/file.py)function or module.function syntax.
+
+    Args:
+        spec: Callable specification string.
+        yaml_dir: Directory of the YAML file (for resolving ./ paths).
+
+    Returns:
+        The resolved callable.
+
+    Raises:
+        Various exceptions if the callable can't be resolved.
+    """
+    parsed = parse_file_callable(spec)
+    if parsed:
+        file_path, func_name = parsed
+        file_path = resolve_file_path(file_path, yaml_dir)
+        return load_callable_from_file(file_path, func_name)
+    else:
+        # Fall back to module.function syntax
+        if "." not in spec:
+            raise ImportError(f"{spec}: module_name.function_name or (file.py)function expected")
+        module_name, func_name = spec.rsplit(".", 1)
+        mod = importlib.import_module(module_name)
+        func = getattr(mod, func_name, None)
+        if func is None:
+            raise AttributeError(f"{func_name} not found in module {module_name}")
+        if not callable(func):
+            raise TypeError(f"{module_name}.{func_name} is not callable")
+        return func

--- a/tests/example_file_callable.py
+++ b/tests/example_file_callable.py
@@ -1,0 +1,36 @@
+"""Example standalone Python file for testing (path/file.py)function syntax.
+
+This file is loaded directly via importlib.util, not as a package module.
+"""
+
+from typing import Any, Dict
+
+from scabha.cargo import Parameter
+
+
+def file_function(a: int, b: str):
+    """Simple callable for testing python flavour with file path syntax."""
+    print(f"file_function({a},'{b}')")
+    return a * 3
+
+
+def file_function_dict(a: int, b: str):
+    """Callable that returns a dict of outputs."""
+    print(f"file_function_dict({a},'{b}')")
+    return dict(x=a * 3, y=b + b + b)
+
+
+_extra_schema = dict(
+    extra_param=Parameter(dtype="str", info="an extra parameter added dynamically"),
+)
+
+
+def file_dynamic_schema(params: Dict[str, Any], inputs: Dict[str, Parameter], outputs: Dict[str, Parameter]):
+    """Dynamic schema function loaded from a file path."""
+    inputs = inputs.copy()
+
+    for tag in params.get("tags", []):
+        for key, value in _extra_schema.items():
+            inputs[f"{tag}.{key}"] = value
+
+    return inputs, outputs

--- a/tests/test_file_callable.py
+++ b/tests/test_file_callable.py
@@ -1,0 +1,24 @@
+from .test_recipe import change_test_dir as change_test_dir
+from .test_recipe import run, verify_output
+
+
+def test_file_callable():
+    """Test python flavour cab with (path/file.py)function syntax."""
+    print("===== testing (path/file.py)function syntax for python callable =====")
+    retcode, output = run("stimela -v -b native run test_file_callable.yml test_file_callables")
+    assert retcode == 0
+    print(output)
+    # s2 should produce x=21 (7*3) and y=worldworldworld (world*3)
+    assert verify_output(output, "y = worldworldworld")
+
+
+def test_file_callable_dynschema():
+    """Test dynamic_schema with (path/file.py)function syntax.
+
+    This only tests that the YAML loads and the dynamic schema is applied
+    (via doc command which triggers finalization).
+    """
+    print("===== testing (path/file.py)function syntax for dynamic schema =====")
+    retcode, output = run("stimela -v doc test_file_callable.yml")
+    assert retcode == 0
+    print(output)

--- a/tests/test_file_callable.yml
+++ b/tests/test_file_callable.yml
@@ -1,0 +1,55 @@
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime}
+    nest: 3
+    symlink: logs
+
+cabs:
+  test_file_callable:
+    command: (./example_file_callable.py)file_function
+    flavour:
+      kind: python
+    inputs:
+      a:
+        dtype: int
+      b:
+        dtype: str
+
+  test_file_callable_dict:
+    command: (./example_file_callable.py)file_function_dict
+    flavour:
+      kind: python
+      output_dict: true
+    inputs:
+      a:
+        dtype: int
+      b:
+        dtype: str
+    outputs:
+      x:
+        dtype: int
+      y:
+        dtype: str
+
+  test_file_dynschema:
+    command: echo
+    inputs:
+      tags:
+        dtype: List[str]
+        required: true
+        policies:
+          repeat: list
+    dynamic_schema: (./example_file_callable.py)file_dynamic_schema
+
+test_file_callables:
+  steps:
+    s1:
+      cab: test_file_callable
+      params:
+        a: 5
+        b: "hello"
+    s2:
+      cab: test_file_callable_dict
+      params:
+        a: 7
+        b: "world"

--- a/tests/test_file_callable_utils.py
+++ b/tests/test_file_callable_utils.py
@@ -1,0 +1,106 @@
+"""Unit tests for the (path/file.py)function utility functions."""
+
+import os
+
+import pytest
+
+from stimela.kitchen.utils import (
+    load_callable_from_file,
+    parse_file_callable,
+    resolve_callable,
+    resolve_file_path,
+)
+
+
+class TestParseFileCallable:
+    def test_basic(self):
+        assert parse_file_callable("(foo.py)bar") == ("foo.py", "bar")
+
+    def test_with_path(self):
+        assert parse_file_callable("(path/to/foo.py)bar") == ("path/to/foo.py", "bar")
+
+    def test_with_slash_separator(self):
+        assert parse_file_callable("(path/to/foo.py)/bar") == ("path/to/foo.py", "bar")
+
+    def test_relative_dot_path(self):
+        assert parse_file_callable("(./foo.py)bar") == ("./foo.py", "bar")
+
+    def test_relative_dotdot_path(self):
+        assert parse_file_callable("(../foo.py)bar") == ("../foo.py", "bar")
+
+    def test_not_matching_module_syntax(self):
+        assert parse_file_callable("module.function") is None
+
+    def test_not_matching_no_parens(self):
+        assert parse_file_callable("function") is None
+
+    def test_not_matching_no_py_extension(self):
+        assert parse_file_callable("(foo.txt)bar") is None
+
+
+class TestResolveFilePath:
+    def test_absolute_path(self):
+        result = resolve_file_path("/absolute/path/foo.py")
+        assert result == "/absolute/path/foo.py"
+
+    def test_relative_path_no_yaml_dir(self):
+        result = resolve_file_path("foo.py")
+        assert result == os.path.abspath("foo.py")
+
+    def test_dot_relative_with_yaml_dir(self):
+        result = resolve_file_path("./foo.py", "/some/yaml/dir")
+        assert result == "/some/yaml/dir/foo.py"
+
+    def test_dotdot_relative_with_yaml_dir(self):
+        result = resolve_file_path("../foo.py", "/some/yaml/dir")
+        assert result == "/some/yaml/foo.py"
+
+    def test_non_dot_relative_ignores_yaml_dir(self):
+        result = resolve_file_path("foo.py", "/some/yaml/dir")
+        assert result == os.path.abspath("foo.py")
+
+
+class TestLoadCallableFromFile:
+    def test_load_function(self, tmp_path):
+        # Create a temporary Python file
+        py_file = tmp_path / "test_mod.py"
+        py_file.write_text("def my_func(x):\n    return x * 2\n")
+
+        func = load_callable_from_file(str(py_file), "my_func")
+        assert callable(func)
+        assert func(5) == 10
+
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_callable_from_file("/nonexistent/path.py", "func")
+
+    def test_function_not_found(self, tmp_path):
+        py_file = tmp_path / "test_mod.py"
+        py_file.write_text("def other_func():\n    pass\n")
+
+        with pytest.raises(AttributeError):
+            load_callable_from_file(str(py_file), "missing_func")
+
+    def test_not_callable(self, tmp_path):
+        py_file = tmp_path / "test_mod.py"
+        py_file.write_text("NOT_A_FUNC = 42\n")
+
+        with pytest.raises(TypeError):
+            load_callable_from_file(str(py_file), "NOT_A_FUNC")
+
+
+class TestResolveCallable:
+    def test_file_syntax(self, tmp_path):
+        py_file = tmp_path / "resolver_test.py"
+        py_file.write_text("def greet(name):\n    return f'hello {name}'\n")
+
+        func = resolve_callable(f"({py_file})greet")
+        assert func("world") == "hello world"
+
+    def test_module_syntax(self):
+        func = resolve_callable("os.path.join")
+        assert func("a", "b") == os.path.join("a", "b")
+
+    def test_invalid_syntax(self):
+        with pytest.raises(ImportError):
+            resolve_callable("nodotshere")


### PR DESCRIPTION
## Summary

- Add support for `(path/to/file.py)function` syntax as an alternative to `module.function` for specifying Python callables
- Works for both **dynamic schemas** (`dynamic_schema:` field) and **python flavour cabs** (`command:` field with `flavour: python`)
- Paths starting with `./` are resolved relative to the YAML file's directory; other paths are resolved relative to CWD
- Uses `importlib.util.spec_from_file_location` to load modules directly from file paths without requiring them to be importable

Closes #565

## Test plan

- [x] Unit tests for parsing/resolution utilities (`tests/test_file_callable_utils.py` -- 20 tests)
- [x] Integration test for python flavour cab with file path syntax (`test_file_callable`)
- [x] Integration test for dynamic schema with file path syntax (`test_file_callable_dynschema`)
- [x] All existing tests continue to pass (pre-existing `test_test_recipe` failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)