### PR TITLE
Fix 6 recipe.py issues (#349, #317, #362, #460, #433, #307)

### DIFF
--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -857,6 +857,11 @@ class Recipe(Cargo):
         # our own parameters are prevalidated against the outer substitution context;
         # step parameters are prevalidated against our own subst
         subst_outer = subst.copy()
+        # scrub the parent recipe's 'recipe' namespace from subst_outer to prevent
+        # sub-recipe inputs/outputs from accidentally accessing parent variables
+        # via {recipe.xxx} (see #433). The correct namespace for sub-recipes is 'current'.
+        if "recipe" in subst_outer:
+            del subst_outer["recipe"]
         self._update_subst_namespace(subst)
 
         # update assignments

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -96,6 +96,9 @@ class Recipe(Cargo):
     # make recipe a for_loop-gather (i.e. parallel for loop)
     for_loop: Optional[ForLoopClause] = None
 
+    # optional message to display after a successful run (supports {}-substitutions)
+    summary_message: Optional[str] = None
+
     def __post_init__(self):
         Cargo.__post_init__(self)
         # flatten aliases and assignments
@@ -1473,6 +1476,21 @@ class Recipe(Cargo):
         subst.current = subst.recipe
 
         self.log.info(f"recipe '{self.name}' executed successfully")
+
+        # evaluate and print summary_message if defined
+        if self.summary_message:
+            try:
+                message = evaluate_and_substitute_object(
+                    self.summary_message,
+                    subst,
+                    recursion_level=-1,
+                    location=[self.fqname, "summary_message"],
+                    log=self.log,
+                )
+                self.log.info(f"summary: {message}")
+            except Exception as exc:
+                self.log.warning(f"error evaluating summary_message: {exc}")
+
         return OrderedDict((name, value) for name, value in params.items() if name in self.outputs)
 
     def to_dag(self, graph: Optional[nx.DiGraph] = None, parent: Optional[str] = None) -> nx.DiGraph:

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -654,6 +654,18 @@ class Recipe(Cargo):
             if schema.required and not have_step_param and (orig_schema is None or orig_schema.required is None):
                 alias_schema.required = True
 
+            # warn if the alias name collides with another parameter of the same step
+            # (this can cause confusing substitution errors, see #460)
+            if alias_name != step_param_name and alias_name in step.inputs_outputs:
+                colliding_io = "input" if alias_name in step.inputs else "output"
+                self.log.warning(
+                    f"recipe '{self.name}': alias '{alias_name}' (pointing to "
+                    f"'{step_label}.{step_param_name}') has the same name as a step "
+                    f"{colliding_io} '{step_label}.{alias_name}'. This may cause "
+                    f"confusing substitution errors if the step uses '{{current.{alias_name}}}' "
+                    f"in formulas. Consider renaming the alias."
+                )
+
             self._alias_map[step_label, step_param_name] = alias_name, orig_schema
             self._alias_list.setdefault(alias_name, []).append(Recipe.AliasInfo(step_label, step, step_param_name, io))
 

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -340,6 +340,9 @@ class Recipe(Cargo):
                 self.inputs_outputs[key].default = UNSET
             else:
                 self.defaults[key] = value
+                # propagate value to step aliases if recipe is finalized
+                if self._alias_map is not None:
+                    self._update_aliases(key, value)
         # assigning to a substep? Invoke nested assignment
         elif nesting is not None and nesting in self.steps:
             return self.steps[nesting].assign_value(subkey, value, override=override)

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -575,6 +575,20 @@ class Recipe(Cargo):
             else:
                 # get recipe's original schema for the parameter
                 io = self.inputs if input_schema else self.outputs
+                # check for input/output direction mismatch: if the alias name was explicitly declared
+                # in the recipe's inputs or outputs, it must match the step parameter's direction
+                if input_schema and alias_name in self.outputs:
+                    raise RecipeValidationError(
+                        f"recipe '{self.name}': output '{alias_name}' is aliased to step input "
+                        f"'{step_label}.{step_param_name}'. Output aliases must refer to step outputs.",
+                        log=self.log,
+                    )
+                if output_schema and alias_name in self.inputs:
+                    raise RecipeValidationError(
+                        f"recipe '{self.name}': input '{alias_name}' is aliased to step output "
+                        f"'{step_label}.{step_param_name}'. Input aliases must refer to step inputs.",
+                        log=self.log,
+                    )
                 # if we have a schema defined for the alias, some params must be inherited from it
                 orig_schema = io.get(alias_name)
                 self._orig_alias_schema[alias_name] = orig_schema

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -681,6 +681,16 @@ class Recipe(Cargo):
             # call Cargo's finalize method
             super().finalize(config, log=log, fqname=fqname, nesting=nesting)
 
+            # warn about inputs being assigned to via the assign section
+            for key in self.assign:
+                if key in self.inputs:
+                    self.log.warning(
+                        f"recipe '{self.name}': assign section sets input '{key}'. "
+                        f"Assigning to inputs via 'assign' is deprecated and may be "
+                        f"removed in a future version. Use the 'defaults' section or "
+                        f"pass the value via the command line instead."
+                    )
+
             # finalize steps
             for label, step in self.steps.items():
                 step_log = log.getChild(label)

--- a/tests/test_recipe_fixes.py
+++ b/tests/test_recipe_fixes.py
@@ -1,0 +1,94 @@
+"""Tests for recipe.py fixes (issues #349, #317, #362, #460, #433, #307)."""
+
+import re
+import subprocess
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def change_test_dir(request, monkeypatch):
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+def run(command):
+    """Runs command, returns tuple of exit code, output (combined stdout+stderr)."""
+    print(f"running: {command}")
+    try:
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).strip().decode()
+        return 0, output
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode, exc.output.strip().decode()
+
+
+def verify_output(output, *regexes):
+    """Check that regexes appear in order in the output string."""
+    output = re.sub(r"\s+", " ", output)
+    regex = "(.*?)".join(regexes)
+    count = len(re.findall(regex, output))
+    if not count:
+        print("Error, expected regex pattern did not appear in the output:")
+        print(f"  {regex}")
+        return 0
+    return count
+
+
+# --- Issue #349: check input/output direction for aliases ---
+
+
+def test_349_input_aliased_to_step_output():
+    """A recipe input aliased to a step output should raise an error."""
+    retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-349-input-to-output")
+    print(output)
+    assert retcode != 0
+    assert verify_output(output, "input.*aliased to step output")
+
+
+def test_349_output_aliased_to_step_input():
+    """A recipe output aliased to a step input should raise an error."""
+    retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-349-output-to-input")
+    print(output)
+    assert retcode != 0
+    assert verify_output(output, "output.*aliased to step input")
+
+
+# --- Issue #362: assign to an input should be prohibited ---
+
+
+def test_362_assign_to_input_prohibited():
+    """Having an input in the assign section should raise an error."""
+    retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-362-assign-to-input")
+    print(output)
+    assert retcode != 0
+    assert verify_output(output, "assign.*input")
+
+
+# --- Issue #460: improved error for alias/step name collision ---
+
+
+def test_460_alias_step_collision_message():
+    """When an alias shares a name with a step input, the error should be clear."""
+    retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-460-alias-step-collision")
+    print(output)
+    # The recipe may or may not error, but if it does the message should mention
+    # the collision between alias name and step parameter name
+    if retcode != 0:
+        assert verify_output(output, "alias.*bar.*conflicts.*step.*input|bar.*same name")
+
+
+# --- Issue #307: recipe summary_message ---
+
+
+def test_307_summary_message():
+    """A recipe with summary_message should print it after successful execution."""
+    retcode, output = run("stimela -v -b native run test_recipe_fixes.yml test-307-summary-message")
+    print(output)
+    assert retcode == 0
+    assert verify_output(output, "Recipe completed with a=success")
+
+
+def test_307_no_summary_message():
+    """A recipe without summary_message should run without issues."""
+    retcode, output = run("stimela -v -b native run test_recipe_fixes.yml test-307-no-summary")
+    print(output)
+    assert retcode == 0

--- a/tests/test_recipe_fixes.py
+++ b/tests/test_recipe_fixes.py
@@ -87,6 +87,16 @@ def test_317_assign_propagates_to_alias():
     assert verify_output(output, "b=assigned_value")
 
 
+def test_433_subrecipe_namespace_scrubbed():
+    """Sub-recipe defaults should not resolve parent recipe namespace during prevalidation."""
+    retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-433-subrecipe-namespace")
+    print(output)
+    # The sub-recipe input x defaults to {recipe.parent_var}. During prevalidation,
+    # the parent recipe's namespace should be scrubbed, so the default should be
+    # Unresolved (not resolved to the parent's value).
+    assert verify_output(output, "Unresolved.*recipe.parent_var.*invalid key")
+
+
 def test_307_summary_message():
     """A recipe with summary_message should print it after successful execution."""
     retcode, output = run("stimela -v -b native run test_recipe_fixes_307.yml test-307-summary-message")

--- a/tests/test_recipe_fixes.py
+++ b/tests/test_recipe_fixes.py
@@ -1,4 +1,4 @@
-"""Tests for recipe.py fixes (issues #349, #317, #362, #460, #433, #307)."""
+"""Tests for recipe.py fixes (issues #349, #317, #362, #460, #433)."""
 
 import re
 import subprocess
@@ -71,11 +71,12 @@ def test_460_alias_step_collision_message():
     """When an alias shares a name with a step input, a warning should explain the collision."""
     retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-460-alias-step-collision")
     print(output)
-    # Should produce a warning about the alias name colliding with a step parameter
+    # Should succeed but produce a warning about the alias name colliding with a step parameter
+    assert retcode == 0
     assert verify_output(output, "alias.*bar.*same name.*step.*input.*sleep-1.bar")
 
 
-# --- Issue #307: recipe summary_message ---
+# --- Issue #317: assign propagation to aliases ---
 
 
 def test_317_assign_propagates_to_alias():

--- a/tests/test_recipe_fixes.py
+++ b/tests/test_recipe_fixes.py
@@ -68,13 +68,11 @@ def test_362_assign_to_input_deprecated():
 
 
 def test_460_alias_step_collision_message():
-    """When an alias shares a name with a step input, the error should be clear."""
+    """When an alias shares a name with a step input, a warning should explain the collision."""
     retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-460-alias-step-collision")
     print(output)
-    # The recipe may or may not error, but if it does the message should mention
-    # the collision between alias name and step parameter name
-    if retcode != 0:
-        assert verify_output(output, "alias.*bar.*conflicts.*step.*input|bar.*same name")
+    # Should produce a warning about the alias name colliding with a step parameter
+    assert verify_output(output, "alias.*bar.*same name.*step.*input.*sleep-1.bar")
 
 
 # --- Issue #307: recipe summary_message ---

--- a/tests/test_recipe_fixes.py
+++ b/tests/test_recipe_fixes.py
@@ -79,9 +79,18 @@ def test_460_alias_step_collision_message():
 # --- Issue #307: recipe summary_message ---
 
 
+def test_317_assign_propagates_to_alias():
+    """A recipe input set via assign should propagate its value to step aliases."""
+    retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-317-assign-alias-propagation")
+    print(output)
+    assert retcode == 0
+    # The assigned value should appear in the step's command line
+    assert verify_output(output, "b=assigned_value")
+
+
 def test_307_summary_message():
     """A recipe with summary_message should print it after successful execution."""
-    retcode, output = run("stimela -v -b native run test_recipe_fixes.yml test-307-summary-message")
+    retcode, output = run("stimela -v -b native run test_recipe_fixes_307.yml test-307-summary-message")
     print(output)
     assert retcode == 0
     assert verify_output(output, "Recipe completed with a=success")
@@ -89,6 +98,6 @@ def test_307_summary_message():
 
 def test_307_no_summary_message():
     """A recipe without summary_message should run without issues."""
-    retcode, output = run("stimela -v -b native run test_recipe_fixes.yml test-307-no-summary")
+    retcode, output = run("stimela -v -b native run test_recipe_fixes_307.yml test-307-no-summary")
     print(output)
     assert retcode == 0

--- a/tests/test_recipe_fixes.py
+++ b/tests/test_recipe_fixes.py
@@ -55,12 +55,13 @@ def test_349_output_aliased_to_step_input():
 # --- Issue #362: assign to an input should be prohibited ---
 
 
-def test_362_assign_to_input_prohibited():
-    """Having an input in the assign section should raise an error."""
+def test_362_assign_to_input_deprecated():
+    """Having an input in the assign section should produce a deprecation warning."""
     retcode, output = run("stimela -v -b native exec test_recipe_fixes.yml test-362-assign-to-input")
     print(output)
-    assert retcode != 0
-    assert verify_output(output, "assign.*input")
+    # Should succeed but produce a deprecation warning
+    assert retcode == 0
+    assert verify_output(output, "assign.*input.*deprecated")
 
 
 # --- Issue #460: improved error for alias/step name collision ---

--- a/tests/test_recipe_fixes.yml
+++ b/tests/test_recipe_fixes.yml
@@ -1,0 +1,120 @@
+## Test recipes for recipe.py fixes
+
+cabs:
+  echo:
+    image: null
+    command: echo
+    policies:
+      skip_implicits: false
+      key_value: true
+    inputs:
+      a:
+        dtype: str
+        required: true
+      b:
+        dtype: str
+      c:
+        dtype: str
+      foo:
+        dtype: str
+      bar:
+        dtype: str
+    outputs:
+      out:
+        dtype: File
+        implicit: "{current.a}"
+        must_exist: false
+      baz:
+        dtype: File
+        must_exist: false
+        default: baz_value
+
+## Issue #349: input aliased to step output should error
+test-349-input-to-output:
+  name: "test-349-input-to-output"
+  inputs:
+    my-input:
+      dtype: File
+      aliases: [s1.out]
+      default: foo
+  steps:
+    s1:
+      cab: echo
+      params:
+        a: hello
+
+## Issue #349: output aliased to step input should error
+test-349-output-to-input:
+  name: "test-349-output-to-input"
+  outputs:
+    my-output:
+      dtype: str
+      aliases: [s1.b]
+  steps:
+    s1:
+      cab: echo
+      params:
+        a: hello
+
+## Issue #362: assign to an input should be prohibited
+test-362-assign-to-input:
+  name: "test-362-assign-to-input"
+  inputs:
+    my-param:
+      dtype: str
+      default: original
+  assign:
+    my-param: overridden
+  steps:
+    s1:
+      cab: echo
+      params:
+        a: hello
+
+## Issue #460: alias shares name with step input - improved error message
+test-460-alias-step-collision:
+  name: "test-460-alias-step-collision"
+  outputs:
+    bar:
+      aliases:
+        - s1.baz
+  steps:
+    s1:
+      cab: echo
+      params:
+        foo: foo
+
+## Issue #433: sub-recipe accessing parent recipe namespace
+test-433-subrecipe-namespace:
+  name: "test-433-subrecipe-namespace"
+  assign:
+    parent_var: parent_value
+  steps:
+    sub:
+      recipe:
+        name: "sub-recipe"
+        inputs:
+          x:
+            dtype: str
+            default: "{recipe.parent_var}"
+        steps:
+          ss1:
+            cab: echo
+            params:
+              a: hello
+
+## Issue #317: recipe input via assign not propagated to step aliases
+test-317-assign-alias-propagation:
+  name: "test-317-assign-alias-propagation"
+  inputs:
+    my-input:
+      dtype: str
+  aliases:
+    my-input: [s1.b]
+  assign:
+    my-input: assigned_value
+  steps:
+    s1:
+      cab: echo
+      params:
+        a: hello

--- a/tests/test_recipe_fixes.yml
+++ b/tests/test_recipe_fixes.yml
@@ -1,6 +1,22 @@
 ## Test recipes for recipe.py fixes
 
 cabs:
+  sleep460:
+    flavour: python-code
+    command: |
+      import time
+      time.sleep(0)
+    inputs:
+      foo:
+        dtype: str
+      bar:
+        dtype: str
+    outputs:
+      baz:
+        dtype: File
+        default: =IFSET(current.bar, STRIPEXT(current.bar))
+        must_exist: false
+
   echo:
     image: null
     command: echo
@@ -72,15 +88,16 @@ test-362-assign-to-input:
         a: hello
 
 ## Issue #460: alias shares name with step input - improved error message
+## This uses a separate cab with a formula default to reproduce the issue
 test-460-alias-step-collision:
   name: "test-460-alias-step-collision"
   outputs:
     bar:
       aliases:
-        - s1.baz
+        - sleep-1.baz
   steps:
-    s1:
-      cab: echo
+    sleep-1:
+      cab: sleep460
       params:
         foo: foo
 

--- a/tests/test_recipe_fixes.yml
+++ b/tests/test_recipe_fixes.yml
@@ -109,8 +109,7 @@ test-317-assign-alias-propagation:
   inputs:
     my-input:
       dtype: str
-  aliases:
-    my-input: [s1.b]
+      aliases: [s1.b]
   assign:
     my-input: assigned_value
   steps:

--- a/tests/test_recipe_fixes_307.yml
+++ b/tests/test_recipe_fixes_307.yml
@@ -1,0 +1,39 @@
+## Test recipes for issue #307 - summary_message
+
+cabs:
+  echo:
+    image: null
+    command: echo
+    policies:
+      skip_implicits: false
+      key_value: true
+    inputs:
+      a:
+        dtype: str
+        required: true
+    outputs:
+      out:
+        dtype: File
+        implicit: "{current.a}"
+        must_exist: false
+
+## Issue #307: recipe summary_message
+test-307-summary-message:
+  name: "test-307-summary-message"
+  summary_message: "Recipe completed with a={recipe.a_val}"
+  assign:
+    a_val: success
+  steps:
+    s1:
+      cab: echo
+      params:
+        a: hello
+
+## Issue #307: recipe summary_message with no message (should work fine)
+test-307-no-summary:
+  name: "test-307-no-summary"
+  steps:
+    s1:
+      cab: echo
+      params:
+        a: hello


### PR DESCRIPTION
## Summary

This PR addresses 6 open issues that all touch `stimela/kitchen/recipe.py`, each in a separate commit:

- **#349 - Aliases missing check for inputs/outputs confusion**: When a recipe input is aliased to a step output (or vice versa), stimela now raises a clear error instead of silently doing the wrong thing. The check validates that input aliases point to step inputs and output aliases point to step outputs.

- **#317 - Recipe input via assign not propagated to step aliases**: When `assign_value` sets a recipe input/output that has aliases, the value is now propagated to the aliased step parameters via `_update_aliases`. Previously the assignment updated defaults but did not propagate to steps.

- **#362 - Assign to an input should be prohibited**: A deprecation warning is now emitted during finalization when an input appears in the recipe's `assign` section. Per discussion on the issue, this is a warning (not a hard error) to ease migration. The assign section should be used for local variables only.

- **#460 - Cryptic error in complex alias/step name collision case**: When an alias shares a name with a different parameter of the same step, a clear warning is now emitted explaining the potential for confusing substitution errors. Previously this scenario could produce cryptic parsing errors.

- **#433 - Recipe substitution namespace should be scrubbed for sub-recipes**: The parent recipe's `recipe` substitution namespace is now removed from the outer substitution context during sub-recipe prevalidation. This prevents sub-recipe input/output defaults from accidentally accessing parent variables via `{recipe.xxx}`. The correct namespace for sub-recipes is `current`. Note: this is a prevalidation-level fix; runtime substitutions in step params passed from parent to child still work correctly.

- **#307 - Add recipe result message string**: Recipes now support an optional `summary_message` property that gets evaluated with `{}`-substitutions and printed at the end of a successful run. This allows recipe authors to display human-readable summaries of results.

## Test plan

- [x] New tests added in `tests/test_recipe_fixes.py` and `tests/test_recipe_fixes_307.yml` covering all 6 fixes
- [x] Existing `test_test_aliasing` and `test_test_nesting` tests pass
- [x] Pre-existing `test_test_recipe` failure (unrelated file existence check) confirmed to exist on master before these changes
- [ ] Full test suite passes (excluding pre-existing failures)

Closes #349, closes #317, closes #362, closes #460, closes #433, closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)