### PR TITLE
Add versioning support for cabs, parameters, and recipes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "python-benedict>=0.34.1,<0.35",
     "rich>=13.7.0,<14",
     "scabha>=2.2.0rc0",
-    "psutil>=5.9,<7"
+    "psutil>=5.9,<7",
+    "packaging>=21.0"
 ]
 
 [tool.hatch.metadata]

--- a/stimela/config.py
+++ b/stimela/config.py
@@ -6,6 +6,9 @@ import time
 import traceback
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import distributions as get_distributions
+from importlib.metadata import version as get_pkg_version
 from typing import Any, Dict, List, Optional
 
 import psutil
@@ -188,6 +191,7 @@ def load_config(
         opts: StimelaOptions = EmptyClassDefault(StimelaOptions)
         vars: Dict[str, Any] = EmptyDictDefault()
         run: Dict[str, Any] = EmptyDictDefault()
+        packages: Dict[str, str] = EmptyDictDefault()
 
     base_configs = lib_configs = cab_configs = []
 
@@ -306,6 +310,27 @@ def load_config(
     runtime["ncpu-physical"] = psutil.cpu_count(logical=False)
 
     conf.run = OmegaConf.create(runtime)
+
+    # populate packages namespace with installed package versions
+    packages = OrderedDict()
+    # populate key packages known to stimela
+    for pkg_name in ["stimela", "scabha", "cultcargo"]:
+        try:
+            packages[pkg_name] = get_pkg_version(pkg_name)
+        except PackageNotFoundError:
+            pass
+    # also populate all installed packages (for general use in formulas)
+    try:
+        for dist in get_distributions():
+            name = dist.metadata["Name"]
+            ver = dist.metadata["Version"]
+            if name and ver:
+                # normalize name (replace hyphens with underscores for valid attribute access)
+                norm_name = name.replace("-", "_").lower()
+                packages[norm_name] = ver
+    except Exception:
+        pass  # don't fail config loading if this fails
+    conf.packages = OmegaConf.create(dict(packages))
 
     # add include paths
     if conf.opts.include:

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import os.path
 import re
 import shlex
@@ -11,6 +12,8 @@ import rich.markup
 import yaml
 from omegaconf import MISSING, DictConfig, OmegaConf
 from omegaconf.errors import OmegaConfBaseException
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 from scabha.basetypes import EmptyClassDefault, EmptyDictDefault, EmptyListDefault
 from scabha.cargo import Cargo, ListOrString, Parameter, ParameterCategory, ParameterPolicies
 from scabha.exceptions import SchemaError
@@ -72,6 +75,56 @@ class ImageInfo(object):
 ImageInfoSchema = OmegaConf.structured(ImageInfo)
 
 
+def _strip_cc_suffix(version_str: str) -> str:
+    """Strips the -ccX.Y.Z suffix from a version string, if present.
+
+    This suffix is a cult-cargo convention for tagging image versions
+    with the cult-cargo release that built them.
+    """
+    return re.sub(r"-cc\d+(\.\d+)*$", "", version_str)
+
+
+def _apply_version_specifiers(inputs_outputs, cab_version_str, log=None):
+    """Activates or deactivates parameters based on their version specifiers.
+
+    For each parameter with a 'versions' field, compares its specifier against
+    the cab version. Parameters that don't match are deactivated (marked _active=False)
+    and have their required flag cleared.
+
+    Args:
+        inputs_outputs: dict of name -> Parameter
+        cab_version_str: the version string of the cab
+        log: optional logger
+    """
+    if not cab_version_str:
+        return
+    try:
+        cab_ver = Version(cab_version_str)
+    except InvalidVersion:
+        if log:
+            log.warning(f"cab version '{cab_version_str}' is not a valid version, skipping version-based filtering")
+        return
+
+    for name, schema in inputs_outputs.items():
+        if schema.versions:
+            try:
+                spec = SpecifierSet(schema.versions)
+            except InvalidSpecifier:
+                if log:
+                    log.warning(f"parameter '{name}': invalid version specifier '{schema.versions}'")
+                continue
+            if cab_ver not in spec:
+                schema._active = False
+                schema.required = False
+                if log:
+                    log.debug(
+                        f"parameter '{name}' deactivated: cab version {cab_ver} "
+                        f"does not match specifier '{schema.versions}'"
+                    )
+            else:
+                schema._active = True
+
+
 @dataclass
 class Cab(Cargo):
     """Represents a cab i.e. an atomic task in a recipe.
@@ -89,6 +142,10 @@ class Cab(Cargo):
     # if set, the cab is run in a container, and this is the image name
     # if not set, commands are run by the native runner
     image: Optional[Any] = None
+
+    # optional version string for the cab. If not set, auto-populated from image.version
+    # (with any -ccX.Y.Z suffix stripped). Used for version-based parameter filtering.
+    version: Optional[str] = None
 
     # command to run, inside the container or natively
     # this is not split into individual arguments, but passed to sh -c as is
@@ -136,6 +193,15 @@ class Cab(Cargo):
             else:
                 raise CabValidationError(f"cab {self.name}: invalid image setting")
 
+        # auto-populate version from image.version if not explicitly set
+        if self.version is None and self.image and self.image.version:
+            version_str = self.image.version
+            if version_str != "latest":
+                self.version = _strip_cc_suffix(version_str)
+
+        # apply version specifiers to parameters
+        _apply_version_specifiers(self.inputs_outputs, self.version, log=logging.getLogger(self.name or "cab"))
+
         # setup wranglers
         self._wranglers = []
         for pattern, actions in self.management.wranglers.items():
@@ -177,6 +243,8 @@ class Cab(Cargo):
         tree.add(f"command: {self.command}")
         if self.image:
             tree.add(f"image: {self.image}")
+        if self.version:
+            tree.add(f"version: {self.version}")
         ## moved to backend.native options
         # if self.virtual_env:
         #     tree.add(f"virtual environment: {self.virtual_env}")
@@ -225,10 +293,13 @@ class Cab(Cargo):
 
     def filter_input_params(self, params: Dict[str, Any], apply_nom_de_guerre=True):
         """Filters dict of params, returning only those that should be passed to a cab
-        (i.e. inputs or named outputs, and not skipped and not implicit)
+        (i.e. inputs or named outputs, and not skipped and not implicit and not deactivated by version)
         """
         filtered_params = OrderedDict()
         for name, schema in self.inputs_outputs.items():
+            # skip parameters deactivated by version specifier
+            if not getattr(schema, "_active", True):
+                continue
             # get skip setting
             skip = self.get_schema_policy(schema, "skip")
             if skip is None and schema.implicit:

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -106,20 +106,20 @@ def _apply_version_specifiers(inputs_outputs, cab_version_str, log=None):
         return
 
     for name, schema in inputs_outputs.items():
-        if schema.versions:
+        versions = getattr(schema, "versions", None)
+        if versions:
             try:
-                spec = SpecifierSet(schema.versions)
+                spec = SpecifierSet(versions)
             except InvalidSpecifier:
                 if log:
-                    log.warning(f"parameter '{name}': invalid version specifier '{schema.versions}'")
+                    log.warning(f"parameter '{name}': invalid version specifier '{versions}'")
                 continue
             if cab_ver not in spec:
                 schema._active = False
                 schema.required = False
                 if log:
                     log.debug(
-                        f"parameter '{name}' deactivated: cab version {cab_ver} "
-                        f"does not match specifier '{schema.versions}'"
+                        f"parameter '{name}' deactivated: cab version {cab_ver} does not match specifier '{versions}'"
                     )
             else:
                 schema._active = True

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -8,12 +8,14 @@ from collections.abc import Mapping
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from io import StringIO
-from typing import Any, Dict, Optional, Tuple, Union, get_origin
+from typing import Any, Dict, List, Optional, Tuple, Union, get_origin
 
 import networkx as nx
 import rich.table
 from omegaconf import DictConfig, ListConfig, OmegaConf
-from scabha.basetypes import UNSET, Placeholder
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+from scabha.basetypes import UNSET, EmptyListDefault, Placeholder
 from scabha.cargo import Cargo, Parameter, ParameterCategory
 from scabha.substitutions import SubstitutionNS
 from scabha.validate import Unresolved, evaluate_and_substitute, evaluate_and_substitute_object
@@ -96,6 +98,12 @@ class Recipe(Cargo):
     # make recipe a for_loop-gather (i.e. parallel for loop)
     for_loop: Optional[ForLoopClause] = None
 
+    # optional version string for the recipe
+    version: Optional[str] = None
+
+    # list of dependency version requirements (PyPI-style), e.g. ["cultcargo >= 0.1.2", "stimela >= 2.0"]
+    requires: List[str] = EmptyListDefault()
+
     def __post_init__(self):
         Cargo.__post_init__(self)
         # flatten aliases and assignments
@@ -105,6 +113,9 @@ class Recipe(Cargo):
             for name, schema in io.items():
                 if not schema:
                     raise RecipeValidationError(f"recipe '{self.name}': '{name}' does not define a valid schema")
+        # convert requires from OmegaConf to list if needed
+        if isinstance(self.requires, (ListConfig,)):
+            self.requires = list(self.requires)
         # check for repeated aliases
         for name, alias_list in self.aliases.items():
             if name in self.inputs_outputs:
@@ -150,6 +161,65 @@ class Recipe(Cargo):
         self._for_loop_values = self._for_loop_scatter = None
         # process pool used to run for-loops
         self._loop_pool = None
+
+    def _check_requirements(self, log=None):
+        """Check that all dependency requirements in the 'requires' section are met.
+
+        Each entry in self.requires is a PyPI-style requirement string like
+        "cultcargo >= 0.1.2" or "stimela >= 2.0, < 3.0".
+
+        Raises:
+            RecipeValidationError: if any requirement is not met
+        """
+        if not self.requires:
+            return
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as get_version
+
+        errors = []
+        for req_str in self.requires:
+            # parse "package_name specifier" e.g. "cultcargo >= 0.1.2, <= 0.1.3"
+            match = re.match(r"^\s*([\w][\w.-]*)\s*(.*?)\s*$", req_str)
+            if not match:
+                errors.append(f"invalid requirement string: '{req_str}'")
+                continue
+            pkg_name = match.group(1)
+            spec_str = match.group(2)
+
+            # get installed version
+            try:
+                installed_version_str = get_version(pkg_name)
+            except PackageNotFoundError:
+                errors.append(f"required package '{pkg_name}' is not installed")
+                continue
+
+            if not spec_str:
+                # no version specifier, just check that the package is installed
+                if log:
+                    log.debug(f"requirement '{req_str}': {pkg_name}=={installed_version_str} installed")
+                continue
+
+            try:
+                spec = SpecifierSet(spec_str)
+            except InvalidSpecifier:
+                errors.append(f"invalid version specifier in requirement '{req_str}'")
+                continue
+
+            try:
+                installed_ver = Version(installed_version_str)
+            except InvalidVersion:
+                errors.append(
+                    f"installed version '{installed_version_str}' of '{pkg_name}' is not a valid version string"
+                )
+                continue
+
+            if installed_ver not in spec:
+                errors.append(f"requirement '{req_str}' not met: installed version is {installed_version_str}")
+            elif log:
+                log.debug(f"requirement '{req_str}': {pkg_name}=={installed_version_str} OK")
+
+        if errors:
+            raise RecipeValidationError(f"recipe '{self.name}': {len(errors)} unmet requirement(s)", errors)
 
     def validate_assignments(self, assign, assign_based_on, location):
         # collect a list of all assignments
@@ -664,6 +734,9 @@ class Recipe(Cargo):
             # call Cargo's finalize method
             super().finalize(config, log=log, fqname=fqname, nesting=nesting)
 
+            # check requirements
+            self._check_requirements(log=log)
+
             # finalize steps
             for label, step in self.steps.items():
                 step_log = log.getChild(label)
@@ -759,6 +832,9 @@ class Recipe(Cargo):
         info.label = label
         info.label_parts = parts
         info.suffix = parts[-1] if len(parts) > 1 else ""
+        # propagate version from cab/recipe into the substitution namespace
+        if step.cargo:
+            info.version = getattr(step.cargo, "version", None) or ""
         subst.current = step.params
         subst.steps[label] = subst.current
 
@@ -791,7 +867,14 @@ class Recipe(Cargo):
     def _update_subst_namespace(self, subst: SubstitutionNS):
         """Updates subst namespace at start of prevalidate or run"""
         taskname = subst.get("self", {}).get("taskname") or self.fqname
-        info = SubstitutionNS(fqname=self.fqname, taskname=taskname, label="", label_parts=[], suffix="")
+        info = SubstitutionNS(
+            fqname=self.fqname,
+            taskname=taskname,
+            label="",
+            label_parts=[],
+            suffix="",
+            version=self.version or "",
+        )
         # nosubst=True means these sub-namespaces are not subject to {}-substitutions
         subst._add_("info", info, nosubst=True)
         subst.self = subst.info

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -335,7 +335,7 @@ class Step:
                 if schema and not getattr(schema, "_active", True):
                     self.log.warning(
                         f"parameter '{name}' is not available in version {self.cargo.version} "
-                        f"of cab '{self.cargo.name}' (requires {schema.versions}), ignoring"
+                        f"of cab '{self.cargo.name}' (requires {getattr(schema, 'versions', '?')}), ignoring"
                     )
                     del params[name]
         if self.cargo.has_dynamic_schemas:

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -328,6 +328,16 @@ class Step:
         self.finalize(backend=backend)
         # apply dynamic schemas
         params = self.params
+        # check for parameters that have been deactivated by version specifiers
+        if isinstance(self.cargo, Cab):
+            for name in list(params.keys()):
+                schema = self.cargo.inputs_outputs.get(name)
+                if schema and not getattr(schema, "_active", True):
+                    self.log.warning(
+                        f"parameter '{name}' is not available in version {self.cargo.version} "
+                        f"of cab '{self.cargo.name}' (requires {schema.versions}), ignoring"
+                    )
+                    del params[name]
         if self.cargo.has_dynamic_schemas:
             # prevalidate in order to resolve substitutions in existing parameters
             params = self.cargo.prevalidate(params, subst, root=root)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -113,9 +113,15 @@ class TestConfigPackages:
         """Config should have packages namespace with installed versions."""
         retcode, output = run("stimela -v -b native exec test_versioning.yml versioned_recipe msg=hello")
         assert retcode == 0
-        # The packages namespace should be available in config
-        # We can't easily check the namespace directly from CLI, but
-        # we verify the run succeeds and the config loads properly
+
+    def test_packages_populated_unit(self):
+        """Config.packages should contain stimela version after load_config."""
+        import stimela
+        from stimela.config import load_config
+
+        config = load_config()
+        assert hasattr(config, "packages")
+        assert config.packages.stimela == stimela.__version__
 
 
 # ---- Issue #306: Version specifiers on parameters ----
@@ -147,9 +153,9 @@ class TestVersionSpecifiers:
         )
         # old_feature has versions: "<2.0" and cab version is 2.0.0
         # so it should be deactivated and produce a warning or be rejected
-        # The step validator will detect it as an unknown parameter in the step
-        # since it's deactivated. This may succeed or fail depending on strict validation.
-        print(output)
+        assert retcode == 0 or verify_output(output, "not available in version|ignoring|deactivated|unknown")
+        if retcode == 0:
+            assert verify_output(output, "not available in version|ignoring|deactivated")
 
     def test_param_version_filtering_unit(self):
         """Unit test: version specifier filtering activates/deactivates correctly."""

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,307 @@
+"""Tests for versioning features (issues #374, #306, #373)."""
+
+import re
+import subprocess
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def change_test_dir(request, monkeypatch):
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+def run(command):
+    """Runs command, returns tuple of exit code, output"""
+    print(f"running: {command}")
+    try:
+        return 0, subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).strip().decode()
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode, exc.output.strip().decode()
+
+
+def verify_output(output, *regexes):
+    """Check that all regex patterns appear in output in order."""
+    output = re.sub(r"\s+", " ", output)
+    regex = "(.*?)".join(regexes)
+    count = len(re.findall(regex, output))
+    if not count:
+        print("Error, expected regex pattern did not appear in the output:")
+        print(f"  {regex}")
+        return 0
+    return count
+
+
+# ---- Issue #374: Version field on Cab and config.packages ----
+
+
+class TestCabVersion:
+    """Tests for cab version field population (#374)."""
+
+    def test_explicit_version(self):
+        """Cab with explicit version should preserve it."""
+
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(command="echo", version="1.2.3")
+        assert cab.version == "1.2.3"
+
+    def test_version_from_image(self):
+        """Cab should auto-populate version from image.version."""
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(command="echo", image="test-image:3.1.0")
+        assert cab.version == "3.1.0"
+
+    def test_version_from_image_strip_cc(self):
+        """Cab should strip -ccX.Y.Z suffix from image version."""
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(command="echo", image="test-image:3.1.0-cc0.2.0")
+        assert cab.version == "3.1.0"
+
+    def test_version_from_image_latest(self):
+        """Cab with image version 'latest' should not set version."""
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(command="echo", image="test-image:latest")
+        assert cab.version is None
+
+    def test_version_none_no_image(self):
+        """Cab without image and without explicit version should have None."""
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(command="echo")
+        assert cab.version is None
+
+    def test_explicit_version_not_overridden_by_image(self):
+        """Explicit version should not be overridden by image version."""
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(command="echo", version="5.0.0", image="test-image:3.1.0")
+        assert cab.version == "5.0.0"
+
+
+class TestStripCcSuffix:
+    """Tests for the _strip_cc_suffix helper."""
+
+    def test_strip_simple(self):
+        from stimela.kitchen.cab import _strip_cc_suffix
+
+        assert _strip_cc_suffix("3.1.0-cc0.2.0") == "3.1.0"
+
+    def test_strip_three_part(self):
+        from stimela.kitchen.cab import _strip_cc_suffix
+
+        assert _strip_cc_suffix("1.0.0-cc1.2.3") == "1.0.0"
+
+    def test_no_suffix(self):
+        from stimela.kitchen.cab import _strip_cc_suffix
+
+        assert _strip_cc_suffix("3.1.0") == "3.1.0"
+
+    def test_strip_two_part(self):
+        from stimela.kitchen.cab import _strip_cc_suffix
+
+        assert _strip_cc_suffix("3.1.0-cc0.2") == "3.1.0"
+
+
+class TestConfigPackages:
+    """Tests for config.packages namespace (#374)."""
+
+    def test_packages_populated(self):
+        """Config should have packages namespace with installed versions."""
+        retcode, output = run("stimela -v -b native exec test_versioning.yml versioned_recipe msg=hello")
+        assert retcode == 0
+        # The packages namespace should be available in config
+        # We can't easily check the namespace directly from CLI, but
+        # we verify the run succeeds and the config loads properly
+
+
+# ---- Issue #306: Version specifiers on parameters ----
+
+
+class TestVersionSpecifiers:
+    """Tests for parameter version specifiers (#306)."""
+
+    def test_active_params_kept(self):
+        """Parameters matching version specifier should be active."""
+        from scabha.cargo import Parameter
+
+        from stimela.kitchen.cab import _apply_version_specifiers
+
+        p_active = Parameter(dtype="str", versions=">=2.0")
+        params = {"p_active": p_active}
+        _apply_version_specifiers(params, "2.0.0")
+        assert p_active._active is True
+
+    def test_versioned_cab_active_params(self):
+        """Parameters matching version should stay active in versioned cab."""
+        retcode, output = run("stimela -v -b native exec test_versioning.yml versioned_recipe msg=hello")
+        assert retcode == 0
+
+    def test_versioned_cab_deactivated_param_warning(self):
+        """Supplying a deactivated parameter should produce a warning."""
+        retcode, output = run(
+            "stimela -v -b native exec test_versioning.yml versioned_recipe msg=hello old_feature=test"
+        )
+        # old_feature has versions: "<2.0" and cab version is 2.0.0
+        # so it should be deactivated and produce a warning or be rejected
+        # The step validator will detect it as an unknown parameter in the step
+        # since it's deactivated. This may succeed or fail depending on strict validation.
+        print(output)
+
+    def test_param_version_filtering_unit(self):
+        """Unit test: version specifier filtering activates/deactivates correctly."""
+        from scabha.cargo import Parameter
+
+        from stimela.kitchen.cab import _apply_version_specifiers
+
+        p1 = Parameter(dtype="str", versions=">=2.0")
+        p2 = Parameter(dtype="str", versions="<2.0")
+        p3 = Parameter(dtype="str", versions=">=1.5,<3.0")
+        p4 = Parameter(dtype="str")  # no version specifier
+
+        params = {"p1": p1, "p2": p2, "p3": p3, "p4": p4}
+        _apply_version_specifiers(params, "2.0.0")
+
+        assert p1._active is True
+        assert p2._active is False
+        assert p3._active is True
+        assert p4._active is True  # no specifier means always active
+
+    def test_param_version_filtering_no_cab_version(self):
+        """When cab has no version, all params stay active."""
+        from scabha.cargo import Parameter
+
+        from stimela.kitchen.cab import _apply_version_specifiers
+
+        p1 = Parameter(dtype="str", versions=">=2.0")
+        params = {"p1": p1}
+        _apply_version_specifiers(params, None)
+
+        assert p1._active is True
+
+    def test_param_version_filtering_invalid_version(self):
+        """Invalid cab version should not crash, just skip filtering."""
+        from scabha.cargo import Parameter
+
+        from stimela.kitchen.cab import _apply_version_specifiers
+
+        p1 = Parameter(dtype="str", versions=">=2.0")
+        params = {"p1": p1}
+        _apply_version_specifiers(params, "not-a-version")
+
+        assert p1._active is True  # should remain active if version is invalid
+
+    def test_image_versioned_cab_filtering(self):
+        """Cab with image version should filter params based on stripped version."""
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(command="echo", image="test-image:3.1.0-cc0.2.0")
+        # version should be 3.1.0 after stripping
+        assert cab.version == "3.1.0"
+
+    def test_unversioned_cab_all_active(self):
+        """Cab without version should keep all params active regardless of specifiers."""
+        from scabha.cargo import Parameter
+
+        from stimela.kitchen.cab import _apply_version_specifiers
+
+        p1 = Parameter(dtype="str", versions=">=1.0")
+        params = {"p1": p1}
+        _apply_version_specifiers(params, None)
+        assert p1._active is True
+
+
+# ---- Issue #373: Recipe requirements ----
+
+
+class TestRecipeRequirements:
+    """Tests for recipe dependency requirements (#373)."""
+
+    def test_requirements_met(self):
+        """Recipe with met requirements should succeed."""
+        retcode, output = run("stimela -v -b native exec test_versioning.yml recipe_with_requires msg=hello")
+        assert retcode == 0
+
+    def test_version_requirements_met(self):
+        """Recipe with met version requirements should succeed."""
+        retcode, output = run("stimela -v -b native exec test_versioning.yml recipe_with_version_requires msg=hello")
+        assert retcode == 0
+
+    def test_unmet_version_requirement(self):
+        """Recipe with unmet version requirement should fail."""
+        retcode, output = run("stimela -v -b native exec test_versioning.yml recipe_with_bad_requires msg=hello")
+        assert retcode != 0
+        assert verify_output(output, "unmet requirement")
+
+    def test_missing_package_requirement(self):
+        """Recipe requiring a non-existent package should fail."""
+        retcode, output = run("stimela -v -b native exec test_versioning.yml recipe_with_missing_pkg msg=hello")
+        assert retcode != 0
+        assert verify_output(output, "not installed")
+
+    def test_check_requirements_unit(self):
+        """Unit test: _check_requirements validates correctly."""
+        from stimela.kitchen.recipe import Recipe
+
+        recipe = Recipe(name="test_req", steps={})
+        recipe.requires = ["stimela", "scabha"]
+        # Should not raise
+        recipe._check_requirements()
+
+    def test_check_requirements_version_unit(self):
+        """Unit test: _check_requirements validates version specifiers."""
+        from stimela.kitchen.recipe import Recipe
+
+        recipe = Recipe(name="test_req", steps={})
+        recipe.requires = ["stimela >= 1.0"]
+        # Should not raise (stimela >= 1.0 is always true for 2.x)
+        recipe._check_requirements()
+
+    def test_check_requirements_bad_version_unit(self):
+        """Unit test: _check_requirements raises on unmet version."""
+        from stimela.exceptions import RecipeValidationError
+        from stimela.kitchen.recipe import Recipe
+
+        recipe = Recipe(name="test_req", steps={})
+        recipe.requires = ["stimela >= 99.0"]
+        with pytest.raises(RecipeValidationError, match="unmet requirement"):
+            recipe._check_requirements()
+
+    def test_check_requirements_missing_pkg_unit(self):
+        """Unit test: _check_requirements raises on missing package."""
+        from stimela.exceptions import RecipeValidationError
+        from stimela.kitchen.recipe import Recipe
+
+        recipe = Recipe(name="test_req", steps={})
+        recipe.requires = ["nonexistent_xyz_pkg_123"]
+        with pytest.raises(RecipeValidationError, match="unmet requirement"):
+            recipe._check_requirements()
+
+
+# ---- Issue #374: Recipe version field ----
+
+
+class TestRecipeVersion:
+    """Tests for recipe version field (#374)."""
+
+    def test_recipe_version_set(self):
+        """Recipe should accept a version field."""
+        from stimela.kitchen.recipe import Recipe
+
+        recipe = Recipe(name="test_recipe", version="1.0.0", steps={})
+        assert recipe.version == "1.0.0"
+
+    def test_recipe_version_none(self):
+        """Recipe without version should have None."""
+        from stimela.kitchen.recipe import Recipe
+
+        recipe = Recipe(name="test_recipe", steps={})
+        assert recipe.version is None
+
+    def test_versioned_recipe_runs(self):
+        """Recipe with version should run successfully."""
+        retcode, output = run("stimela -v -b native exec test_versioning.yml versioned_recipe msg=hello")
+        assert retcode == 0

--- a/tests/test_versioning.yml
+++ b/tests/test_versioning.yml
@@ -1,0 +1,138 @@
+## Test cabs and recipes for versioning features
+
+cabs:
+  # A cab with an explicit version
+  versioned_echo:
+    command: echo
+    version: "2.0.0"
+    inputs:
+      msg:
+        dtype: str
+        required: true
+      # parameter available in all versions
+      common_param:
+        dtype: str
+        default: "common"
+      # parameter only available in version >= 2.0
+      new_feature:
+        dtype: str
+        default: "new"
+        versions: ">=2.0"
+      # parameter deprecated since version 2.0
+      old_feature:
+        dtype: str
+        versions: "<2.0"
+      # parameter available in version range
+      ranged_feature:
+        dtype: str
+        versions: ">=1.5,<3.0"
+        default: "ranged"
+
+  # A cab with version from image
+  image_versioned_echo:
+    command: echo
+    image:
+      name: test-image
+      version: "3.1.0-cc0.2.0"
+    inputs:
+      msg:
+        dtype: str
+        required: true
+      # Only in version >= 3.0
+      v3_feature:
+        dtype: str
+        versions: ">=3.0"
+        default: "v3"
+      # Only in version < 3.0
+      legacy_feature:
+        dtype: str
+        versions: "<3.0"
+
+  # A cab with no version (version-specifiers on params should not filter)
+  unversioned_echo:
+    command: echo
+    inputs:
+      msg:
+        dtype: str
+        required: true
+      # This has a version specifier but cab has no version, so it stays active
+      maybe_feature:
+        dtype: str
+        versions: ">=1.0"
+        default: "maybe"
+
+# Test recipe with version
+versioned_recipe:
+  name: versioned recipe
+  version: "1.0.0"
+  inputs:
+    msg:
+      dtype: str
+      required: true
+  steps:
+    echo:
+      cab: versioned_echo
+      params:
+        msg: "{recipe.msg}"
+
+# Test recipe with requirements
+recipe_with_requires:
+  name: recipe with requirements
+  requires:
+    - stimela
+    - scabha
+  inputs:
+    msg:
+      dtype: str
+      required: true
+  steps:
+    echo:
+      cab: versioned_echo
+      params:
+        msg: "{recipe.msg}"
+
+# Test recipe with version requirements that should pass
+recipe_with_version_requires:
+  name: recipe with version requires
+  requires:
+    - stimela >= 1.0
+    - scabha >= 1.0
+  inputs:
+    msg:
+      dtype: str
+      required: true
+  steps:
+    echo:
+      cab: versioned_echo
+      params:
+        msg: "{recipe.msg}"
+
+# Test recipe with unmet requirements (should fail)
+recipe_with_bad_requires:
+  name: recipe with bad requires
+  requires:
+    - stimela >= 99.0
+  inputs:
+    msg:
+      dtype: str
+      required: true
+  steps:
+    echo:
+      cab: versioned_echo
+      params:
+        msg: "{recipe.msg}"
+
+# Test recipe with missing package requirement (should fail)
+recipe_with_missing_pkg:
+  name: recipe with missing pkg
+  requires:
+    - nonexistent_package_xyz123
+  inputs:
+    msg:
+      dtype: str
+      required: true
+  steps:
+    echo:
+      cab: versioned_echo
+      params:
+        msg: "{recipe.msg}"


### PR DESCRIPTION
## Summary

Implements three related versioning features from the R2.3 milestone:

- **#374 - Version field on Cab/Recipe + config.packages**: Adds an optional `version` field to `Cab` (auto-populated from `image.version` with `-ccX.Y.Z` suffix stripped) and `Recipe`. Populates `config.packages` namespace with installed package versions. Propagates version into substitution namespace as `{self.version}` / `{info.version}`.

- **#306 - Version specifiers on parameters**: Adds a `versions` field to `Parameter` (PyPI-style, e.g. `">=3.1"`). Parameters are activated/deactivated by comparing their specifier against the cab version. Deactivated parameters are skipped during argument building, have their `required` flag cleared, and produce warnings if explicitly supplied.

- **#373 - Recipe requirements**: Adds a `requires` section to `Recipe` for specifying dependency versions (e.g. `["cultcargo >= 0.1.2", "stimela >= 2.0"]`). Requirements are checked during recipe finalization using `importlib.metadata` and raise clear errors if not met.

### Key design decisions

- Uses the `packaging` library (PEP 440) for version parsing and comparison
- The `-ccX.Y.Z` suffix (cult-cargo convention) is automatically stripped when deriving cab version from image version
- When a cab has no version, version specifiers on parameters are ignored (all params remain active)
- Invalid version strings produce warnings rather than errors, to avoid breaking existing workflows
- `config.packages` includes all installed packages (normalized names) for use in formulas

### scabha dependency

This PR requires a corresponding change in scabha to add the `versions: Optional[str] = None` field and `_active: bool = True` attribute to the `Parameter` dataclass. The change is minimal (3 lines in `scabha/cargo.py`).

Closes #374, closes #306, closes #373

## Test plan

- [x] 30 new tests in `tests/test_versioning.py` covering:
  - Cab version auto-population from image, explicit version, cc-suffix stripping
  - Parameter version specifier filtering (activate/deactivate)
  - Recipe requirements validation (met, unmet, missing packages)
  - Recipe version field
  - Integration tests via stimela CLI
- [x] All existing tests pass (aliasing, nesting, conditional skips, issue-527, output elements, param file, run state)
- [x] Lint clean (ruff check + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)