### PR TITLE
Add deprecation warning mechanism and related features (#371, #313, #444)

### DIFF
--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -26,6 +26,7 @@ import stimela.backends
 import stimela.config
 from stimela import log_exception, logger, stimelogging, task_stats
 from stimela.config import ConfigExceptionTypes
+from stimela.deprecation import get_deprecation_summary, has_deprecation_warnings
 from stimela.display.display import display
 from stimela.exceptions import RecipeValidationError, StepSelectionError, StepValidationError, StimelaRuntimeError
 from stimela.kitchen.recipe import Recipe, RecipeSchema, Step
@@ -721,6 +722,11 @@ def run(
             print_depth=profile if profile is not None else stimela.CONFIG.opts.profile.print_depth,
             unroll_loops=stimela.CONFIG.opts.profile.unroll_loops,
         )
+
+    if has_deprecation_warnings():
+        stimelogging.declare_chapter("deprecation warnings")
+        for line in get_deprecation_summary():
+            outer_step.log.warning(line)
 
     if stimelogging.has_accumulated_messages():
         stimelogging.declare_chapter("accumulated warnings and errors")

--- a/stimela/deprecation.py
+++ b/stimela/deprecation.py
@@ -1,0 +1,91 @@
+"""Central deprecation warning mechanism for Stimela.
+
+This module provides a way to issue and collect deprecation warnings throughout
+a Stimela run, printing each unique warning only on first occurrence, and
+providing a summary of all warnings at the end of the run.
+
+Addresses https://github.com/caracal-pipeline/stimela/issues/371
+"""
+
+import logging
+import warnings
+from collections import OrderedDict
+from typing import Optional
+
+import rich.markup
+
+from . import stimelogging
+
+# Registry of all deprecation warnings issued during this run.
+# Keyed by (category_label, message) to suppress duplicates.
+_deprecation_registry: OrderedDict[tuple, dict] = OrderedDict()
+
+
+def deprecation_warning(
+    message: str,
+    category: str = "general",
+    log: Optional[logging.Logger] = None,
+):
+    """Issue a deprecation warning.
+
+    The warning is logged immediately on first occurrence and collected for
+    a summary at the end of the run.  Subsequent calls with the same
+    *category* and *message* are silently suppressed.
+
+    Args:
+        message: Human-readable deprecation message.
+        category: Short label grouping related warnings (e.g. "cab",
+            "nom_de_guerre").  Used for deduplication and the summary.
+        log: Logger to emit the warning to.  Falls back to the global
+            Stimela logger when ``None``.
+    """
+    key = (category, message)
+    if key in _deprecation_registry:
+        _deprecation_registry[key]["count"] += 1
+        return
+
+    _deprecation_registry[key] = {"count": 1}
+
+    # Also issue a Python-level FutureWarning so that programmatic callers
+    # (e.g. test suites) can catch it with the warnings module.
+    warnings.warn(message, FutureWarning, stacklevel=2)
+
+    # Log via stimelogging's accumulated-message mechanism so the warning
+    # appears both immediately and in the end-of-run summary.
+    if log is None:
+        from . import logger
+
+        log = logger()
+
+    styled_msg = f"[bold yellow]Deprecation warning[/bold yellow]: {rich.markup.escape(message)}"
+
+    stimelogging.log_and_remember(
+        log,
+        styled_msg,
+        label=key,
+        severity="warning",
+        suppress_repeat=True,
+        at_end=True,
+    )
+
+
+def has_deprecation_warnings() -> bool:
+    """Return True if any deprecation warnings have been issued."""
+    return bool(_deprecation_registry)
+
+
+def get_deprecation_summary() -> list[str]:
+    """Return a list of summary lines for all collected deprecation warnings."""
+    lines = []
+    for (category, message), info in _deprecation_registry.items():
+        count = info["count"]
+        if count > 1:
+            lines.append(f"  [{category}] {message} (x{count})")
+        else:
+            lines.append(f"  [{category}] {message}")
+    return lines
+
+
+def clear_deprecation_warnings():
+    """Clear all collected deprecation warnings. Mainly useful for testing."""
+    _deprecation_registry.clear()

--- a/stimela/deprecation.py
+++ b/stimela/deprecation.py
@@ -50,8 +50,9 @@ def deprecation_warning(
     # (e.g. test suites) can catch it with the warnings module.
     warnings.warn(message, FutureWarning, stacklevel=2)
 
-    # Log via stimelogging's accumulated-message mechanism so the warning
-    # appears both immediately and in the end-of-run summary.
+    # Log the warning immediately. The end-of-run summary is handled
+    # separately by get_deprecation_summary() in run.py, so we do not
+    # use at_end=True here to avoid double-printing.
     if log is None:
         from . import logger
 
@@ -65,7 +66,7 @@ def deprecation_warning(
         label=key,
         severity="warning",
         suppress_repeat=True,
-        at_end=True,
+        at_end=False,
     )
 
 
@@ -78,11 +79,12 @@ def get_deprecation_summary() -> list[str]:
     """Return a list of summary lines for all collected deprecation warnings."""
     lines = []
     for (category, message), info in _deprecation_registry.items():
+        escaped_msg = rich.markup.escape(message)
         count = info["count"]
         if count > 1:
-            lines.append(f"  [{category}] {message} (x{count})")
+            lines.append(f"  \\[{category}] {escaped_msg} (x{count})")
         else:
-            lines.append(f"  [{category}] {message}")
+            lines.append(f"  \\[{category}] {escaped_msg}")
     return lines
 
 

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -118,6 +118,10 @@ class Cab(Cargo):
     # default parameter conversion policies
     policies: ParameterPolicies = EmptyClassDefault(ParameterPolicies)
 
+    # if set, marks the cab as deprecated. The string value is a message
+    # explaining the deprecation (e.g. what to use instead).
+    deprecated: Optional[str] = None
+
     def __post_init__(self):
         Cargo.__post_init__(self)
         for param in self.inputs.keys():
@@ -161,6 +165,49 @@ class Cab(Cargo):
                 OmegaConf.merge(StimelaBackendSchema, self.backend)
             except OmegaConfBaseException as exc:
                 raise CabValidationError(f"cab {self.name}: invalid backend setting", exc)
+
+        # Build cab-level alias map.
+        # If a parameter declares aliases that match other parameter names
+        # within this cab, those aliased names are treated as deprecated
+        # names for the canonical parameter.  _cab_alias_map maps
+        # deprecated-name -> canonical-name.
+        self._cab_alias_map = {}
+        all_params = set(self.inputs_outputs.keys())
+        for name, schema in self.inputs_outputs.items():
+            if schema.aliases:
+                for alias in schema.aliases:
+                    # only consider simple names (no dots) that are NOT
+                    # already defined as their own parameters
+                    if "." not in alias and alias not in all_params:
+                        self._cab_alias_map[alias] = name
+
+    def resolve_cab_aliases(self, params, log=None):
+        """Resolve cab-level parameter aliases in the given params dict.
+
+        If a parameter was passed under a deprecated alias name, it is
+        remapped to its canonical name and a deprecation warning is issued.
+
+        Returns the (possibly modified) params dict.
+        """
+        if not self._cab_alias_map:
+            return params
+
+        from stimela.deprecation import deprecation_warning
+
+        remapped = OrderedDict()
+        for name, value in params.items():
+            if name in self._cab_alias_map:
+                canonical = self._cab_alias_map[name]
+                deprecation_warning(
+                    f"parameter '{name}' of cab '{self.name}' is a deprecated alias "
+                    f"for '{canonical}'. Please use '{canonical}' instead.",
+                    category="parameter_alias",
+                    log=log,
+                )
+                remapped[canonical] = value
+            else:
+                remapped[name] = value
+        return remapped
 
     def summary(self, params=None, recursive=True, ignore_missing=False):
         lines = [f"cab {self.name}:"]

--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -198,6 +198,15 @@ class Cab(Cargo):
         for name, value in params.items():
             if name in self._cab_alias_map:
                 canonical = self._cab_alias_map[name]
+                if canonical in params:
+                    deprecation_warning(
+                        f"parameter '{name}' of cab '{self.name}' is a deprecated alias "
+                        f"for '{canonical}'. Both were supplied; using the canonical "
+                        f"'{canonical}' value and ignoring '{name}'.",
+                        category="parameter_alias",
+                        log=log,
+                    )
+                    continue
                 deprecation_warning(
                     f"parameter '{name}' of cab '{self.name}' is a deprecated alias "
                     f"for '{canonical}'. Please use '{canonical}' instead.",

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -22,6 +22,7 @@ import stimela
 from stimela import log_exception, stimelogging, task_stats
 from stimela.backends import StimelaBackendSchema, runner
 from stimela.config import EmptyDictDefault, EmptyListDefault
+from stimela.deprecation import deprecation_warning
 from stimela.display.display import display
 from stimela.exceptions import (
     AssignmentError,
@@ -304,6 +305,28 @@ class Step:
             # finalize the cargo
             self.cargo.finalize(config, log=log, fqname=self.fqname, backend=backend, nesting=nesting)
 
+            # check for deprecated cab
+            cab_label = self.cab if type(self.cab) is str else self.cargo.name
+            if isinstance(self.cargo, Cab) and self.cargo.deprecated:
+                deprecation_warning(
+                    f"cab '{cab_label}' is deprecated: {self.cargo.deprecated}",
+                    category="cab",
+                    log=log,
+                )
+
+            # check for deprecated nom_de_guerre usage in parameters
+            if isinstance(self.cargo, Cab):
+                for pname, schema in self.cargo.inputs_outputs.items():
+                    if schema.nom_de_guerre:
+                        deprecation_warning(
+                            f"parameter '{pname}' of cab '{cab_label}' uses "
+                            f"'nom_de_guerre' (set to '{schema.nom_de_guerre}'). "
+                            f"Consider using the 'aliases' parameter property instead. "
+                            f"'nom_de_guerre' may be removed in a future release.",
+                            category="nom_de_guerre",
+                            log=log,
+                        )
+
             # build dictionary of defaults from cargo
             self.defaults = {
                 name: schema.default
@@ -326,6 +349,9 @@ class Step:
 
     def prevalidate(self, subst: SubstitutionNS, root=False, backend=None):
         self.finalize(backend=backend)
+        # resolve cab-level parameter aliases (deprecated name -> canonical name)
+        if isinstance(self.cargo, Cab):
+            self.params = self.cargo.resolve_cab_aliases(self.params, log=self.log)
         # apply dynamic schemas
         params = self.params
         if self.cargo.has_dynamic_schemas:

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,217 @@
+"""Tests for the deprecation warning mechanism (#371), deprecated cab
+property (#313), and parameter alias / nom_de_guerre deprecation (#444).
+"""
+
+import re
+import subprocess
+import warnings
+
+import pytest
+
+from stimela.deprecation import (
+    clear_deprecation_warnings,
+    deprecation_warning,
+    get_deprecation_summary,
+    has_deprecation_warnings,
+)
+
+
+# Change into directory where this test file lives
+@pytest.fixture(autouse=True)
+def change_test_dir(request, monkeypatch):
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+@pytest.fixture(autouse=True)
+def _clear_warnings():
+    """Clear the deprecation registry before each test."""
+    clear_deprecation_warnings()
+    yield
+    clear_deprecation_warnings()
+
+
+def run(command):
+    """Runs command, returns tuple of exit code, output."""
+    print(f"running: {command}")
+    try:
+        return 0, subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).strip().decode()
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode, exc.output.strip().decode()
+
+
+def verify_output(output, *regexes):
+    """Check that the given regexes appear in order in the output."""
+    output = re.sub(r"\s+", " ", output)
+    regex = "(.*?)".join(regexes)
+    count = len(re.findall(regex, output))
+    if not count:
+        print("Error, expected regex pattern did not appear in the output:")
+        print(f"  {regex}")
+        return 0
+    return count
+
+
+# ---- Unit tests for the deprecation module (#371) ----
+
+
+class TestDeprecationModule:
+    """Unit tests for stimela.deprecation."""
+
+    def test_deprecation_warning_registers(self):
+        """deprecation_warning registers warnings and they show up in the summary."""
+        assert not has_deprecation_warnings()
+
+        deprecation_warning("feature X is deprecated", category="test")
+        assert has_deprecation_warnings()
+
+        lines = get_deprecation_summary()
+        assert len(lines) == 1
+        assert "feature X is deprecated" in lines[0]
+        assert "[test]" in lines[0]
+
+    def test_duplicate_suppression(self):
+        """Identical warnings are suppressed after the first occurrence."""
+        deprecation_warning("same warning", category="test")
+        deprecation_warning("same warning", category="test")
+        deprecation_warning("same warning", category="test")
+
+        lines = get_deprecation_summary()
+        assert len(lines) == 1
+        assert "x3" in lines[0]
+
+    def test_different_categories(self):
+        """Warnings with different categories are tracked separately."""
+        deprecation_warning("msg", category="cat_a")
+        deprecation_warning("msg", category="cat_b")
+
+        lines = get_deprecation_summary()
+        assert len(lines) == 2
+
+    def test_different_messages(self):
+        """Warnings with different messages are tracked separately."""
+        deprecation_warning("msg1", category="test")
+        deprecation_warning("msg2", category="test")
+
+        lines = get_deprecation_summary()
+        assert len(lines) == 2
+
+    def test_clear(self):
+        """clear_deprecation_warnings empties the registry."""
+        deprecation_warning("to be cleared", category="test")
+        assert has_deprecation_warnings()
+        clear_deprecation_warnings()
+        assert not has_deprecation_warnings()
+
+    def test_future_warning_issued(self):
+        """A Python FutureWarning is issued for programmatic callers."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            deprecation_warning("test future warning", category="test")
+
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 1
+        assert "test future warning" in str(future_warnings[0].message)
+
+
+# ---- Integration tests for deprecated cab (#313) ----
+
+
+class TestDeprecatedCab:
+    """Integration tests for the 'deprecated' property on cab definitions."""
+
+    def test_deprecated_cab_warns(self):
+        """Running a recipe that uses a deprecated cab should produce a deprecation warning."""
+        retcode, output = run("stimela -v -b native exec test_deprecation.yml test_deprecated_cab")
+        assert retcode == 0
+        assert verify_output(output, "Deprecation warning", "old_cab.*deprecated", "echo_cab")
+
+    def test_non_deprecated_cab_no_warning(self):
+        """A non-deprecated cab should not trigger any deprecation warning."""
+        retcode, output = run("stimela -v -b native exec test_deprecation.yml test_ndg_cab")
+        assert retcode == 0
+        # Should not contain a "cab.*deprecated" warning -- only the nom_de_guerre warning
+        assert not verify_output(output, "cab.*is deprecated")
+
+
+# ---- Integration tests for nom_de_guerre deprecation (#444) ----
+
+
+class TestNomDeGuerreDeprecation:
+    """Integration tests for nom_de_guerre deprecation warnings."""
+
+    def test_nom_de_guerre_warns(self):
+        """Using a parameter with nom_de_guerre should produce a deprecation warning."""
+        retcode, output = run("stimela -v -b native exec test_deprecation.yml test_ndg_cab")
+        assert retcode == 0
+        assert verify_output(output, "Deprecation warning", "nom_de_guerre")
+
+
+# ---- Unit tests for Cab.deprecated field (#313) ----
+
+
+class TestCabDeprecatedField:
+    """Tests that the deprecated field is properly part of the Cab dataclass."""
+
+    def test_cab_has_deprecated_field(self):
+        """Cab should have an optional 'deprecated' field."""
+        import dataclasses
+
+        from stimela.kitchen.cab import Cab
+
+        fields = {f.name: f for f in dataclasses.fields(Cab)}
+        assert "deprecated" in fields
+        assert fields["deprecated"].default is None
+
+
+# ---- Unit tests for cab-level alias resolution (#444) ----
+
+
+class TestCabAliasMap:
+    """Tests for cab-level alias mapping."""
+
+    def test_cab_alias_resolution(self):
+        """Cab.resolve_cab_aliases should remap deprecated parameter names."""
+        from collections import OrderedDict
+
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(
+            command="echo",
+            inputs=OrderedDict(
+                output_column={
+                    "dtype": "str",
+                    "required": True,
+                    "aliases": ["out_col"],
+                }
+            ),
+        )
+
+        params = OrderedDict(out_col="DATA")
+        resolved = cab.resolve_cab_aliases(params)
+
+        assert "output_column" in resolved
+        assert "out_col" not in resolved
+        assert resolved["output_column"] == "DATA"
+
+    def test_cab_no_alias_needed(self):
+        """When canonical name is used, no remapping happens."""
+        from collections import OrderedDict
+
+        from stimela.kitchen.cab import Cab
+
+        cab = Cab(
+            command="echo",
+            inputs=OrderedDict(
+                output_column={
+                    "dtype": "str",
+                    "required": True,
+                    "aliases": ["out_col"],
+                }
+            ),
+        )
+
+        params = OrderedDict(output_column="DATA")
+        resolved = cab.resolve_cab_aliases(params)
+
+        assert "output_column" in resolved
+        assert resolved["output_column"] == "DATA"

--- a/tests/test_deprecation.yml
+++ b/tests/test_deprecation.yml
@@ -1,0 +1,65 @@
+cabs:
+  # A normal, non-deprecated cab for reference
+  echo_cab:
+    command: echo
+    inputs:
+      message:
+        dtype: str
+        required: true
+
+  # A cab marked as deprecated (#313)
+  old_cab:
+    command: echo
+    deprecated: "Use 'echo_cab' instead."
+    inputs:
+      message:
+        dtype: str
+        required: true
+
+  # A cab with nom_de_guerre on a parameter (#444)
+  ndg_cab:
+    command: echo
+    inputs:
+      ms_name:
+        dtype: str
+        required: true
+        nom_de_guerre: ms
+
+  # A cab that uses cab-level aliases to rename a parameter (#444)
+  alias_cab:
+    command: echo
+    inputs:
+      output_column:
+        dtype: str
+        required: true
+        aliases: [out_col]
+
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime}
+    nest: 3
+    symlink: logs
+
+test_deprecated_cab:
+  name: "test deprecated cab"
+  steps:
+    use_old:
+      cab: old_cab
+      params:
+        message: hello
+
+test_ndg_cab:
+  name: "test nom de guerre cab"
+  steps:
+    use_ndg:
+      cab: ndg_cab
+      params:
+        ms_name: test.ms
+
+test_alias_cab:
+  name: "test cab-level alias"
+  steps:
+    use_alias:
+      cab: alias_cab
+      params:
+        out_col: DATA


### PR DESCRIPTION
## Summary

- **#371**: Add central deprecation warning module (`stimela/deprecation.py`) that issues `FutureWarning` on first occurrence, suppresses duplicates, collects all warnings, and prints a categorized summary at the end of a run.
- **#313**: Add optional `deprecated` string field to the `Cab` dataclass. When set, a deprecation warning is emitted when the cab is used in a step, informing the user what to use instead.
- **#444**: Add cab-level parameter alias resolution using the existing `aliases` field on `Parameter`. When a parameter is passed under a deprecated alias name, it is remapped to the canonical name with a deprecation warning. Also emits deprecation warnings when `nom_de_guerre` is used on any parameter, suggesting `aliases` as the future replacement.

## Test plan

- [x] Unit tests for the deprecation module: registration, duplicate suppression, category separation, clearing, FutureWarning emission
- [x] Unit tests for `Cab.deprecated` field existence
- [x] Unit tests for cab-level alias resolution (`resolve_cab_aliases`)
- [x] Integration tests for deprecated cab warning via `stimela exec`
- [x] Integration tests for `nom_de_guerre` deprecation warning via `stimela exec`
- [x] Verified existing tests still pass (test_aliasing, test_nesting, test_loop_recipe, test_issue527)
- [x] Linting and formatting pass (`ruff check`, `ruff format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)