### PR TITLE
R2.3: Add persistent output cache and triage scope/evaluator issues

### DIFF
--- a/stimela/config.py
+++ b/stimela/config.py
@@ -54,6 +54,18 @@ class StimelaDisableSkipOptions(object):
 
 
 @dataclass
+class StimelaCacheOptions(object):
+    """Options for the persistent output cache (see issue #369)."""
+
+    # Whether caching of non-file outputs is enabled
+    enabled: bool = False
+    # Directory for the cache database file
+    dir: str = "."
+    # Database filename (without extension; dbm appends its own)
+    name: str = ".stimela-cache"
+
+
+@dataclass
 class StimelaOptions(object):
     backend: StimelaBackendOptions = EmptyClassDefault(StimelaBackendOptions)
     backend_varieties: Dict[str, Dict] = EmptyDictDefault()
@@ -66,6 +78,8 @@ class StimelaOptions(object):
     profile: StimelaProfilingOptions = EmptyClassDefault(StimelaProfilingOptions)
     ## Disables skip_if_outputs checks
     disable_skips: StimelaDisableSkipOptions = EmptyClassDefault(StimelaDisableSkipOptions)
+    ## Output cache options
+    cache: StimelaCacheOptions = EmptyClassDefault(StimelaCacheOptions)
 
 
 def DefaultDirs():

--- a/stimela/kitchen/cache.py
+++ b/stimela/kitchen/cache.py
@@ -19,7 +19,7 @@ import pickle
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-from scabha.basetypes import UNSET, Unresolved
+from scabha.validate import Unresolved
 
 log = logging.getLogger(__name__)
 
@@ -45,9 +45,9 @@ def _cache_db_path(config: CacheConfig) -> str:
     return os.path.join(config.dir, config.name)
 
 
-def _make_key(recipe_name: str, step_label: str, output_name: str) -> str:
-    """Construct a cache key from recipe name, step label, and output name."""
-    return f"{recipe_name}::{step_label}::{output_name}"
+def _make_key(recipe_name: str, step_label: str, output_name: str, recipe_file: str = "") -> str:
+    """Construct a cache key from recipe file, recipe name, step label, and output name."""
+    return f"{recipe_file}::{recipe_name}::{step_label}::{output_name}"
 
 
 def _hash_inputs(params: Dict[str, Any], schemas: Dict[str, Any]) -> str:
@@ -64,7 +64,7 @@ def _hash_inputs(params: Dict[str, Any], schemas: Dict[str, Any]) -> str:
         if schema is None or not getattr(schema, "is_input", False):
             continue
         value = params[name]
-        if value is UNSET or isinstance(value, Unresolved):
+        if isinstance(value, Unresolved):
             continue
         # pickle the value for a canonical byte representation
         try:
@@ -97,8 +97,9 @@ class OutputCache:
             cache.close()
     """
 
-    def __init__(self, config: CacheConfig):
+    def __init__(self, config: CacheConfig, recipe_file: str = ""):
         self.config = config
+        self.recipe_file = recipe_file
         self._db = None
 
     def open(self):
@@ -123,10 +124,10 @@ class OutputCache:
         return False
 
     def _value_key(self, recipe_name: str, step_label: str, output_name: str) -> str:
-        return _make_key(recipe_name, step_label, output_name)
+        return _make_key(recipe_name, step_label, output_name, self.recipe_file)
 
     def _hash_key(self, recipe_name: str, step_label: str, output_name: str) -> str:
-        return _make_key(recipe_name, step_label, output_name) + "::__input_hash__"
+        return _make_key(recipe_name, step_label, output_name, self.recipe_file) + "::__input_hash__"
 
     def lookup(
         self,
@@ -196,7 +197,7 @@ class OutputCache:
             ]
         else:
             # remove all entries for this step
-            prefix = _make_key(recipe_name, step_label, "")
+            prefix = _make_key(recipe_name, step_label, "", self.recipe_file)
             keys_to_remove = [k for k in self._db.keys() if k.decode("utf-8").startswith(prefix)]
 
         for key in keys_to_remove:
@@ -244,5 +245,5 @@ class OutputCache:
                 continue
             if name in params:
                 value = params[name]
-                if value is not UNSET and not isinstance(value, Unresolved):
+                if not isinstance(value, Unresolved):
                     self.store(recipe_name, step_label, name, value, input_hash)

--- a/stimela/kitchen/cache.py
+++ b/stimela/kitchen/cache.py
@@ -1,0 +1,248 @@
+"""Persistent output cache for non-file step outputs.
+
+Uses Python's dbm module to store a key-value cache of step outputs,
+enabling reuse of previously computed non-file results across runs.
+
+Keys are formed from the recipe filename, recipe name, step label, and
+output name.  Values are pickled Python objects.  An input hash is
+stored alongside each cached value so the cache can be invalidated when
+inputs change.
+
+See https://github.com/caracal-pipeline/stimela/issues/369
+"""
+
+import dbm
+import hashlib
+import logging
+import os
+import pickle
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from scabha.basetypes import UNSET, Unresolved
+
+log = logging.getLogger(__name__)
+
+
+# sentinel returned when no cached value is available
+_CACHE_MISS = object()
+
+
+@dataclass
+class CacheConfig:
+    """Configuration for the output cache."""
+
+    # whether caching is enabled
+    enabled: bool = False
+    # directory for the cache database; defaults to current directory
+    dir: str = "."
+    # database filename (without extension; dbm appends its own)
+    name: str = ".stimela-cache"
+
+
+def _cache_db_path(config: CacheConfig) -> str:
+    """Return the full path to the cache database file."""
+    return os.path.join(config.dir, config.name)
+
+
+def _make_key(recipe_name: str, step_label: str, output_name: str) -> str:
+    """Construct a cache key from recipe name, step label, and output name."""
+    return f"{recipe_name}::{step_label}::{output_name}"
+
+
+def _hash_inputs(params: Dict[str, Any], schemas: Dict[str, Any]) -> str:
+    """Compute a deterministic hash over the input parameter values.
+
+    Only input parameters (not outputs) are included in the hash.
+    Parameters whose values are UNSET or Unresolved are skipped.
+    The hash is used to invalidate cached outputs when inputs change.
+    """
+    hasher = hashlib.sha256()
+    # sort by key for determinism
+    for name in sorted(params.keys()):
+        schema = schemas.get(name)
+        if schema is None or not getattr(schema, "is_input", False):
+            continue
+        value = params[name]
+        if value is UNSET or isinstance(value, Unresolved):
+            continue
+        # pickle the value for a canonical byte representation
+        try:
+            pickled = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+        except (pickle.PicklingError, TypeError):
+            # if a value can't be pickled, include its repr
+            pickled = repr(value).encode("utf-8")
+        hasher.update(name.encode("utf-8"))
+        hasher.update(pickled)
+    return hasher.hexdigest()
+
+
+class OutputCache:
+    """Persistent cache for non-file step outputs.
+
+    Usage::
+
+        cache = OutputCache(config)
+        cache.open()
+        try:
+            # check for cached outputs
+            cached = cache.lookup(recipe_name, step_label, output_name, input_hash)
+            if cached is not _CACHE_MISS:
+                # use cached value
+                ...
+            else:
+                # run step, then store
+                cache.store(recipe_name, step_label, output_name, value, input_hash)
+        finally:
+            cache.close()
+    """
+
+    def __init__(self, config: CacheConfig):
+        self.config = config
+        self._db = None
+
+    def open(self):
+        """Open the cache database, creating it if necessary."""
+        path = _cache_db_path(self.config)
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        self._db = dbm.open(path, "c")
+        log.debug(f"opened output cache at {path}")
+
+    def close(self):
+        """Close the cache database."""
+        if self._db is not None:
+            self._db.close()
+            self._db = None
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def _value_key(self, recipe_name: str, step_label: str, output_name: str) -> str:
+        return _make_key(recipe_name, step_label, output_name)
+
+    def _hash_key(self, recipe_name: str, step_label: str, output_name: str) -> str:
+        return _make_key(recipe_name, step_label, output_name) + "::__input_hash__"
+
+    def lookup(
+        self,
+        recipe_name: str,
+        step_label: str,
+        output_name: str,
+        input_hash: str,
+    ) -> Any:
+        """Look up a cached output value.
+
+        Returns the cached value if the key exists and the input hash matches,
+        otherwise returns ``_CACHE_MISS``.
+        """
+        if self._db is None:
+            return _CACHE_MISS
+
+        vkey = self._value_key(recipe_name, step_label, output_name)
+        hkey = self._hash_key(recipe_name, step_label, output_name)
+
+        if vkey not in self._db or hkey not in self._db:
+            return _CACHE_MISS
+
+        stored_hash = self._db[hkey].decode("utf-8")
+        if stored_hash != input_hash:
+            log.debug(f"cache invalidated for {vkey} (input hash mismatch)")
+            return _CACHE_MISS
+
+        try:
+            value = pickle.loads(self._db[vkey])
+            log.debug(f"cache hit for {vkey}")
+            return value
+        except Exception as exc:
+            log.warning(f"failed to unpickle cached value for {vkey}: {exc}")
+            return _CACHE_MISS
+
+    def store(
+        self,
+        recipe_name: str,
+        step_label: str,
+        output_name: str,
+        value: Any,
+        input_hash: str,
+    ):
+        """Store an output value in the cache."""
+        if self._db is None:
+            return
+
+        vkey = self._value_key(recipe_name, step_label, output_name)
+        hkey = self._hash_key(recipe_name, step_label, output_name)
+
+        try:
+            self._db[vkey] = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+            self._db[hkey] = input_hash.encode("utf-8")
+            log.debug(f"cached {vkey}")
+        except (pickle.PicklingError, TypeError) as exc:
+            log.warning(f"failed to cache {vkey}: {exc}")
+
+    def invalidate(self, recipe_name: str, step_label: str, output_name: Optional[str] = None):
+        """Remove cached entries for a given step (or a specific output)."""
+        if self._db is None:
+            return
+
+        if output_name:
+            keys_to_remove = [
+                self._value_key(recipe_name, step_label, output_name),
+                self._hash_key(recipe_name, step_label, output_name),
+            ]
+        else:
+            # remove all entries for this step
+            prefix = _make_key(recipe_name, step_label, "")
+            keys_to_remove = [k for k in self._db.keys() if k.decode("utf-8").startswith(prefix)]
+
+        for key in keys_to_remove:
+            try:
+                if isinstance(key, str):
+                    key = key.encode("utf-8")
+                del self._db[key]
+            except KeyError:
+                pass
+
+    def lookup_step_outputs(
+        self,
+        recipe_name: str,
+        step_label: str,
+        output_schemas: Dict[str, Any],
+        input_hash: str,
+    ) -> Dict[str, Any]:
+        """Look up all non-file cached outputs for a step.
+
+        Returns a dict of {output_name: cached_value} for outputs that
+        have valid cache entries.  Only non-file outputs are considered.
+        """
+        cached = {}
+        for name, schema in output_schemas.items():
+            # skip file-type outputs -- those are handled by the existing
+            # freshness/existence checks
+            if getattr(schema, "is_file_type", False) or getattr(schema, "is_file_list_type", False):
+                continue
+            value = self.lookup(recipe_name, step_label, name, input_hash)
+            if value is not _CACHE_MISS:
+                cached[name] = value
+        return cached
+
+    def store_step_outputs(
+        self,
+        recipe_name: str,
+        step_label: str,
+        params: Dict[str, Any],
+        output_schemas: Dict[str, Any],
+        input_hash: str,
+    ):
+        """Store all non-file outputs of a step in the cache."""
+        for name, schema in output_schemas.items():
+            if getattr(schema, "is_file_type", False) or getattr(schema, "is_file_list_type", False):
+                continue
+            if name in params:
+                value = params[name]
+                if value is not UNSET and not isinstance(value, Unresolved):
+                    self.store(recipe_name, step_label, name, value, input_hash)

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -21,7 +21,7 @@ from scabha.validate import Unresolved, evaluate_and_substitute_object, join_quo
 import stimela
 from stimela import log_exception, stimelogging, task_stats
 from stimela.backends import StimelaBackendSchema, runner
-from stimela.config import EmptyDictDefault, EmptyListDefault
+from stimela.config import CONFIG_LOADED, EmptyDictDefault, EmptyListDefault
 from stimela.display.display import display
 from stimela.exceptions import (
     AssignmentError,
@@ -739,7 +739,7 @@ class Step:
                 )
                 input_hash = _hash_inputs(params, self.cargo.inputs_outputs)
                 try:
-                    with OutputCache(cache_config) as cache:
+                    with OutputCache(cache_config, recipe_file=CONFIG_LOADED or "") as cache:
                         cached_outputs = cache.lookup_step_outputs(
                             self.fqname, self.name, self.cargo.outputs, input_hash
                         )
@@ -827,7 +827,7 @@ class Step:
                 ## store non-file outputs in cache (issue #369)
                 if cache_enabled and not skip and cache_config is not None and input_hash is not None:
                     try:
-                        with OutputCache(cache_config) as cache:
+                        with OutputCache(cache_config, recipe_file=CONFIG_LOADED or "") as cache:
                             cache.store_step_outputs(self.fqname, self.name, params, self.cargo.outputs, input_hash)
                     except Exception as exc:
                         self.log.debug(f"failed to store outputs in cache: {exc}")

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -33,6 +33,7 @@ from stimela.exceptions import (
 from stimela.stimelogging import log_rich_payload
 
 from .cab import Cab, get_cab_schema
+from .cache import CacheConfig, OutputCache, _hash_inputs
 
 Conditional = Optional[str]
 
@@ -89,6 +90,7 @@ class Step:
     info: Optional[str] = None  # comment or info string
     skip: Optional[str] = None  # if this evaluates to True, step is skipped.
     skip_if_outputs: Optional[str] = None  # skip if outputs "exist' or "fresh"
+    cache_outputs: Optional[bool] = None  # if True, cache non-file outputs for reuse across runs
     tags: List[str] = EmptyListDefault()
 
     name: str = ""  # step's internal name
@@ -716,6 +718,41 @@ class Step:
                     parent_log_info("all required outputs are OK, skipping this step")
                     skip = True
 
+            ## check output cache for non-file outputs (issue #369)
+            has_cache_opts = hasattr(stimela.CONFIG, "opts") and hasattr(stimela.CONFIG.opts, "cache")
+            cache_enabled = (
+                not skip and self.cache_outputs is not False and has_cache_opts and stimela.CONFIG.opts.cache.enabled
+            )
+            # step-level cache_outputs=True can enable even if global is off,
+            # step-level cache_outputs=False disables
+            if not skip and self.cache_outputs is True:
+                cache_enabled = True
+
+            cached_outputs = {}
+            cache_config = None
+            input_hash = None
+            if cache_enabled:
+                cache_config = CacheConfig(
+                    enabled=True,
+                    dir=stimela.CONFIG.opts.cache.dir if has_cache_opts else ".",
+                    name=stimela.CONFIG.opts.cache.name if has_cache_opts else ".stimela-cache",
+                )
+                input_hash = _hash_inputs(params, self.cargo.inputs_outputs)
+                try:
+                    with OutputCache(cache_config) as cache:
+                        cached_outputs = cache.lookup_step_outputs(
+                            self.fqname, self.name, self.cargo.outputs, input_hash
+                        )
+                except Exception as exc:
+                    self.log.debug(f"output cache lookup failed: {exc}")
+                    cached_outputs = {}
+
+                if cached_outputs:
+                    parent_log_info(
+                        f"found {len(cached_outputs)} cached non-file output(s): {', '.join(cached_outputs.keys())}"
+                    )
+                    params.update(**cached_outputs)
+
             if not skip:
                 if self.evaluate_section("preamble", subst):
                     raise StepValidationError("aborting due to above", log=self.log)
@@ -786,6 +823,14 @@ class Step:
                 if subst is not None:
                     subst.current._merge_(params)
                 self.log_summary(logging.DEBUG, "validated outputs", ignore_missing=True, outputs=True)
+
+                ## store non-file outputs in cache (issue #369)
+                if cache_enabled and not skip and cache_config is not None and input_hash is not None:
+                    try:
+                        with OutputCache(cache_config) as cache:
+                            cache.store_step_outputs(self.fqname, self.name, params, self.cargo.outputs, input_hash)
+                    except Exception as exc:
+                        self.log.debug(f"failed to store outputs in cache: {exc}")
 
             if self.evaluate_section("epilogue", subst):
                 raise StepValidationError("aborting due to above", log=self.log)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,207 @@
+"""Tests for the persistent output cache (issue #369)."""
+
+import os
+
+import pytest
+
+from stimela.kitchen.cache import _CACHE_MISS, CacheConfig, OutputCache, _hash_inputs
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    """Provide a temporary directory for cache tests."""
+    return str(tmp_path)
+
+
+@pytest.fixture
+def cache_config(cache_dir):
+    """Provide a CacheConfig pointing at a temp directory."""
+    return CacheConfig(enabled=True, dir=cache_dir, name=".test-cache")
+
+
+class TestOutputCache:
+    """Tests for OutputCache basic operations."""
+
+    def test_store_and_lookup(self, cache_config):
+        """Store a value and look it up; should match."""
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "result", 42, "hash123")
+            value = cache.lookup("recipe1", "step1", "result", "hash123")
+        assert value == 42
+
+    def test_lookup_miss_empty_cache(self, cache_config):
+        """Lookup on an empty cache returns _CACHE_MISS."""
+        with OutputCache(cache_config) as cache:
+            value = cache.lookup("recipe1", "step1", "result", "hash123")
+        assert value is _CACHE_MISS
+
+    def test_lookup_miss_wrong_hash(self, cache_config):
+        """Lookup with a different input hash returns _CACHE_MISS."""
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "result", 42, "hash123")
+            value = cache.lookup("recipe1", "step1", "result", "hash_different")
+        assert value is _CACHE_MISS
+
+    def test_lookup_miss_wrong_key(self, cache_config):
+        """Lookup with a different key returns _CACHE_MISS."""
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "result", 42, "hash123")
+            value = cache.lookup("recipe1", "step2", "result", "hash123")
+        assert value is _CACHE_MISS
+
+    def test_store_overwrite(self, cache_config):
+        """Storing a new value for the same key overwrites the old one."""
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "result", 42, "hash1")
+            cache.store("recipe1", "step1", "result", 99, "hash2")
+            # old hash no longer matches
+            assert cache.lookup("recipe1", "step1", "result", "hash1") is _CACHE_MISS
+            # new hash returns new value
+            assert cache.lookup("recipe1", "step1", "result", "hash2") == 99
+
+    def test_store_complex_types(self, cache_config):
+        """Cache can store and retrieve complex Python objects."""
+        data = {"key": [1, 2, 3], "nested": {"a": True, "b": 3.14}}
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "data", data, "hash1")
+            value = cache.lookup("recipe1", "step1", "data", "hash1")
+        assert value == data
+
+    def test_persistence_across_sessions(self, cache_config):
+        """Cache persists across separate open/close cycles."""
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "result", 42, "hash1")
+
+        # open again and verify
+        with OutputCache(cache_config) as cache:
+            value = cache.lookup("recipe1", "step1", "result", "hash1")
+        assert value == 42
+
+    def test_invalidate_specific_output(self, cache_config):
+        """Invalidating a specific output removes only that entry."""
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "out1", 10, "hash1")
+            cache.store("recipe1", "step1", "out2", 20, "hash1")
+            cache.invalidate("recipe1", "step1", "out1")
+            assert cache.lookup("recipe1", "step1", "out1", "hash1") is _CACHE_MISS
+            assert cache.lookup("recipe1", "step1", "out2", "hash1") == 20
+
+    def test_invalidate_all_step_outputs(self, cache_config):
+        """Invalidating without specifying an output clears all outputs for that step."""
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "out1", 10, "hash1")
+            cache.store("recipe1", "step1", "out2", 20, "hash1")
+            cache.store("recipe1", "step2", "out1", 30, "hash1")
+            cache.invalidate("recipe1", "step1")
+            assert cache.lookup("recipe1", "step1", "out1", "hash1") is _CACHE_MISS
+            assert cache.lookup("recipe1", "step1", "out2", "hash1") is _CACHE_MISS
+            # step2 should be unaffected
+            assert cache.lookup("recipe1", "step2", "out1", "hash1") == 30
+
+    def test_context_manager(self, cache_config):
+        """Cache can be used as a context manager."""
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "result", 42, "hash1")
+            assert cache.lookup("recipe1", "step1", "result", "hash1") == 42
+
+    def test_creates_directory(self, tmp_path):
+        """Cache creates the directory if it doesn't exist."""
+        new_dir = str(tmp_path / "nested" / "cache" / "dir")
+        config = CacheConfig(enabled=True, dir=new_dir, name=".test-cache")
+        with OutputCache(config) as cache:
+            cache.store("recipe1", "step1", "result", 42, "hash1")
+        assert os.path.isdir(new_dir)
+
+
+class TestHashInputs:
+    """Tests for _hash_inputs function."""
+
+    def _make_schema(self, is_input=True):
+        """Create a simple mock schema object."""
+
+        class MockSchema:
+            pass
+
+        s = MockSchema()
+        s.is_input = is_input
+        return s
+
+    def test_same_inputs_same_hash(self):
+        """Identical inputs produce the same hash."""
+        params = {"a": 1, "b": "hello"}
+        schemas = {"a": self._make_schema(), "b": self._make_schema()}
+        h1 = _hash_inputs(params, schemas)
+        h2 = _hash_inputs(params, schemas)
+        assert h1 == h2
+
+    def test_different_inputs_different_hash(self):
+        """Different input values produce different hashes."""
+        schemas = {"a": self._make_schema(), "b": self._make_schema()}
+        h1 = _hash_inputs({"a": 1, "b": "hello"}, schemas)
+        h2 = _hash_inputs({"a": 2, "b": "hello"}, schemas)
+        assert h1 != h2
+
+    def test_output_params_ignored(self):
+        """Output parameters should not affect the hash."""
+        schemas = {
+            "a": self._make_schema(is_input=True),
+            "out": self._make_schema(is_input=False),
+        }
+        h1 = _hash_inputs({"a": 1, "out": "x"}, schemas)
+        h2 = _hash_inputs({"a": 1, "out": "y"}, schemas)
+        assert h1 == h2
+
+    def test_deterministic_ordering(self):
+        """Hash is deterministic regardless of dict insertion order."""
+        schemas = {"a": self._make_schema(), "b": self._make_schema()}
+        from collections import OrderedDict
+
+        p1 = OrderedDict([("a", 1), ("b", 2)])
+        p2 = OrderedDict([("b", 2), ("a", 1)])
+        assert _hash_inputs(p1, schemas) == _hash_inputs(p2, schemas)
+
+
+class TestLookupStepOutputs:
+    """Tests for the batch lookup/store of step outputs."""
+
+    def _make_schema(self, is_file=False, is_file_list=False):
+        class MockSchema:
+            pass
+
+        s = MockSchema()
+        s.is_file_type = is_file
+        s.is_file_list_type = is_file_list
+        return s
+
+    def test_lookup_step_outputs(self, cache_config):
+        """lookup_step_outputs returns cached non-file outputs."""
+        output_schemas = {
+            "result_int": self._make_schema(),
+            "result_file": self._make_schema(is_file=True),
+        }
+        with OutputCache(cache_config) as cache:
+            cache.store("recipe1", "step1", "result_int", 42, "hash1")
+            cache.store("recipe1", "step1", "result_file", "/tmp/file.txt", "hash1")
+
+            cached = cache.lookup_step_outputs("recipe1", "step1", output_schemas, "hash1")
+
+        # only non-file output should be returned
+        assert "result_int" in cached
+        assert cached["result_int"] == 42
+        assert "result_file" not in cached
+
+    def test_store_step_outputs(self, cache_config):
+        """store_step_outputs stores only non-file outputs."""
+
+        output_schemas = {
+            "result_int": self._make_schema(),
+            "result_file": self._make_schema(is_file=True),
+        }
+        params = {"result_int": 42, "result_file": "/tmp/file.txt"}
+
+        with OutputCache(cache_config) as cache:
+            cache.store_step_outputs("recipe1", "step1", params, output_schemas, "hash1")
+            # non-file output should be cached
+            assert cache.lookup("recipe1", "step1", "result_int", "hash1") == 42
+            # file output should NOT be cached
+            assert cache.lookup("recipe1", "step1", "result_file", "hash1") is _CACHE_MISS

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -160,6 +160,17 @@ class TestHashInputs:
         p2 = OrderedDict([("b", 2), ("a", 1)])
         assert _hash_inputs(p1, schemas) == _hash_inputs(p2, schemas)
 
+    def test_unset_instances_skipped(self):
+        """UNSET(name) instances should be skipped, not just the UNSET class sentinel."""
+        from scabha.basetypes import UNSET
+
+        schemas = {"a": self._make_schema(), "b": self._make_schema()}
+        h1 = _hash_inputs({"a": 1, "b": UNSET("b")}, schemas)
+        h2 = _hash_inputs({"a": 1, "b": UNSET("other")}, schemas)
+        h3 = _hash_inputs({"a": 1}, schemas)
+        assert h1 == h2, "different UNSET instances should produce the same hash"
+        assert h1 == h3, "UNSET values should be equivalent to missing params"
+
 
 class TestLookupStepOutputs:
     """Tests for the batch lookup/store of step outputs."""

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -43,6 +43,8 @@ def test_cache_integration():
     assert verify_output(output, "message = hellohello")
     # should mention cached outputs were found
     assert verify_output(output, "cached non-file output")
+    # verify the number of cached outputs matches what we expect (result + message)
+    assert verify_output(output, "2 cached non-file output")
 
     # clean up
     for f in glob.glob(".test-stimela-cache*"):

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -1,0 +1,49 @@
+"""Integration test for the output cache feature (issue #369)."""
+
+import glob
+import os
+
+from .test_recipe import change_test_dir as change_test_dir
+from .test_recipe import run, verify_output
+
+_call_count = 0
+
+
+def cached_function(x: int, y: str):
+    """A function whose outputs we want to cache."""
+    global _call_count
+    _call_count += 1
+    print(f"cached_function({x}, '{y}') call #{_call_count}")
+    return dict(result=x * 2, message=y + y)
+
+
+def test_cache_integration():
+    """Test that output caching works end-to-end via the CLI."""
+    # clean up any leftover cache files
+    for f in glob.glob(".test-stimela-cache*"):
+        os.unlink(f)
+
+    print("===== first run: should execute and cache outputs =====")
+    retcode, output = run("stimela -v -b native run test_cache_integration.yml")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "result = 42")
+    assert verify_output(output, "message = hellohello")
+
+    # verify cache files were created
+    cache_files = glob.glob(".test-stimela-cache*")
+    assert len(cache_files) > 0, "cache database files should have been created"
+
+    print("===== second run: should find cached outputs =====")
+    retcode, output = run("stimela -v -b native run test_cache_integration.yml")
+    assert retcode == 0
+    print(output)
+    # should still produce the correct outputs
+    assert verify_output(output, "result = 42")
+    assert verify_output(output, "message = hellohello")
+    # should mention cached outputs were found
+    assert verify_output(output, "cached non-file output")
+
+    # clean up
+    for f in glob.glob(".test-stimela-cache*"):
+        os.unlink(f)

--- a/tests/test_cache_integration.yml
+++ b/tests/test_cache_integration.yml
@@ -1,0 +1,35 @@
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime}
+    nest: 3
+    symlink: logs
+  cache:
+    enabled: true
+    dir: "."
+    name: ".test-stimela-cache"
+
+cabs:
+  test_callable_cached:
+    command: tests.test_cache_integration.cached_function
+    flavour:
+      kind: python
+      output_dict: true
+    inputs:
+      x:
+        dtype: int
+      y:
+        dtype: str
+    outputs:
+      result:
+        dtype: int
+      message:
+        dtype: str
+
+test_cache_recipe:
+  steps:
+    compute:
+      cab: test_callable_cached
+      cache_outputs: true
+      params:
+        x: 21
+        y: "hello"


### PR DESCRIPTION
## Summary

- **#369 (caching output results)**: Implemented persistent dbm-based cache for non-file step outputs. Includes input parameter hashing for automatic cache invalidation, step-level and global config control, and comprehensive tests (17 unit + 1 integration).
- **#356 (parameter scope)**: Commented on issue -- requires changes to scabha package (now extracted to separate repo). Labeled "humans help!".  
- **#404 (UNSET/Unresolved cleanup)**: Commented on issue with detailed analysis of current state and suggested cleanup approach. Requires scabha changes. Labeled "humans help!".

### Cache feature details (#369)

New files:
- `stimela/kitchen/cache.py` -- `OutputCache` class using Python `dbm` module
- `tests/test_cache.py` -- 17 unit tests for cache operations
- `tests/test_cache_integration.py` + `.yml` -- end-to-end CLI integration test

Modified files:
- `stimela/config.py` -- `StimelaCacheOptions` dataclass added to `StimelaOptions`
- `stimela/kitchen/step.py` -- `cache_outputs` field + cache lookup/store in `Step.run()`

Usage in recipe YAML:
```yaml
opts:
  cache:
    enabled: true
    dir: "."        # cache database directory
    name: ".stimela-cache"  # database filename

recipe:
  steps:
    compute:
      cab: my_cab
      cache_outputs: true  # per-step override
```

## Test plan

- [x] All 17 cache unit tests pass
- [x] Integration test verifies end-to-end cache store and lookup via CLI
- [x] Full test suite passes (83/83, excluding pre-existing `test_test_recipe` failure on macOS)
- [x] Lint and format clean (ruff)

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)