### PR TITLE
Fix skip logic, output cleanup, and list slicing

### DIFF
--- a/stimela/__init__.py
+++ b/stimela/__init__.py
@@ -29,3 +29,9 @@ Path(LOG_HOME).mkdir(exist_ok=True)
 LOG_FILE = "{0:s}/stimela_logfile.json".format(LOG_HOME)
 
 from .stimelogging import logger, log_exception  # noqa
+
+# Apply evaluator patches (adds SLICE function, etc.)
+from .evaluator_patches import apply_patches as _apply_evaluator_patches  # noqa: E402
+
+_apply_evaluator_patches()
+del _apply_evaluator_patches

--- a/stimela/evaluator_patches.py
+++ b/stimela/evaluator_patches.py
@@ -1,0 +1,72 @@
+"""Monkey-patches for scabha's expression evaluator.
+
+This module extends scabha's evaluator with additional functionality needed by stimela:
+
+- SLICE(list, stop) / SLICE(list, start, stop) / SLICE(list, start, stop, step):
+  Function-based list slicing (issue #449). Use UNSET for omitted components.
+
+Examples:
+    =SLICE(recipe.mylist, 5)              # mylist[:5]  (first 5 elements)
+    =SLICE(recipe.mylist, 2, 5)           # mylist[2:5]
+    =SLICE(recipe.mylist, UNSET, 5)       # mylist[:5]
+    =SLICE(recipe.mylist, 0, 10, 2)       # mylist[0:10:2]
+"""
+
+import logging
+
+from scabha.evaluator import FunctionHandler
+
+log = logging.getLogger(__name__)
+
+
+def _SLICE(self, evaluator, args):
+    """SLICE(list, stop) or SLICE(list, start, stop) or SLICE(list, start, stop, step).
+
+    Provides list slicing functionality equivalent to Python's slice syntax.
+    Use UNSET for omitted start/stop/step values.
+    """
+    from scabha.basetypes import UNSET, Unresolved
+    from scabha.exceptions import FormulaError
+
+    if len(args) < 2 or len(args) > 4:
+        raise FormulaError(f"{'.'.join(evaluator.location)}: SLICE() expects 2 to 4 arguments, got {len(args)}")
+
+    list_arg = evaluator._evaluate_result(args[0])
+    if isinstance(list_arg, Unresolved):
+        return list_arg
+
+    eval_args = []
+    for arg in args[1:]:
+        val = evaluator._evaluate_result(arg, allow_unset=True)
+        if val is UNSET or isinstance(val, Unresolved):
+            # Treat UNSET as None (omitted slice component)
+            eval_args.append(None)
+        else:
+            eval_args.append(val)
+
+    if len(eval_args) == 1:
+        # SLICE(list, stop) => list[:stop]
+        return list_arg[: eval_args[0]]
+    elif len(eval_args) == 2:
+        # SLICE(list, start, stop) => list[start:stop]
+        return list_arg[eval_args[0] : eval_args[1]]
+    else:
+        # SLICE(list, start, stop, step) => list[start:stop:step]
+        return list_arg[eval_args[0] : eval_args[1] : eval_args[2]]
+
+
+# Attach SLICE to FunctionHandler so it's available in formulas
+FunctionHandler.SLICE = _SLICE
+
+
+def apply_patches():
+    """Apply all evaluator patches. Called at stimela import time."""
+    import scabha.evaluator
+
+    # Clear the parse cache since we added a new function
+    scabha.evaluator._parse_cache.clear()
+
+    # Reconstruct the parser to pick up the new SLICE function
+    scabha.evaluator._parser = scabha.evaluator.construct_parser()
+
+    log.debug("evaluator patches applied (SLICE function available)")

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -78,6 +78,123 @@ def apply_backend_varieties(backend_opts: DictConfig):
 OUTPUTS_EXISTS = "exist"
 OUTPUTS_FRESH = "fresh"
 
+# Sentinel values for skip_if_outputs modes
+_SKIP_MODES = {OUTPUTS_EXISTS, OUTPUTS_FRESH}
+
+
+def _check_output_existence(params, outputs_schema):
+    """Check which file-type outputs exist.
+
+    Returns a dict mapping output parameter names to booleans indicating
+    whether all file(s) for that output exist.
+    """
+    result = {}
+    for name, schema in outputs_schema.items():
+        if name not in params:
+            continue
+        if schema.is_file_type:
+            value = params[name]
+            if isinstance(value, str):
+                result[name] = os.path.exists(value)
+            else:
+                result[name] = False
+        elif schema.is_file_list_type:
+            filenames = params[name]
+            if not filenames:
+                result[name] = not schema.must_exist
+            else:
+                result[name] = all(isinstance(f, str) and os.path.exists(f) for f in filenames)
+    return result
+
+
+def _check_output_freshness(params, inputs_schema, outputs_schema):
+    """Check which file-type outputs are fresh relative to inputs.
+
+    Returns a dict mapping output parameter names to booleans indicating
+    whether the output is fresh (newer than all inputs).
+    """
+    # Find the most recent input modification time
+    max_mtime = 0
+    for name, value in params.items():
+        schema = {**inputs_schema, **outputs_schema}.get(name)
+        if schema is None or not schema.is_input or schema.skip_freshness_checks:
+            continue
+        if schema.is_file_type:
+            values = [value]
+        elif schema.is_file_list_type:
+            values = value
+        else:
+            continue
+        for filename in values:
+            if isinstance(filename, str) and os.path.exists(filename):
+                mtime = os.path.getmtime(filename)
+                if mtime > max_mtime:
+                    max_mtime = mtime
+
+    result = {}
+    for name, schema in outputs_schema.items():
+        if name not in params:
+            continue
+        if schema.is_file_type:
+            value = params[name]
+            if isinstance(value, str) and os.path.exists(value):
+                if max_mtime == 0 or schema.skip_freshness_checks:
+                    result[name] = True
+                else:
+                    result[name] = os.path.getmtime(value) >= max_mtime
+            else:
+                result[name] = False
+        elif schema.is_file_list_type:
+            filenames = params[name]
+            if not filenames:
+                result[name] = not schema.must_exist
+            else:
+                all_fresh = True
+                for f in filenames:
+                    if isinstance(f, str) and os.path.exists(f):
+                        if max_mtime and not schema.skip_freshness_checks:
+                            if os.path.getmtime(f) < max_mtime:
+                                all_fresh = False
+                                break
+                    elif schema.must_exist is not False:
+                        all_fresh = False
+                        break
+                result[name] = all_fresh
+    return result
+
+
+def _remove_outputs_on_error(params, outputs_schema, log):
+    """Remove output files/directories that have remove_on_error set in metadata.
+
+    This is called when a step fails, to clean up partial outputs (e.g. zarr directories).
+    Set ``metadata: {remove_on_error: true}`` on an output parameter to enable this.
+    """
+    for name, schema in outputs_schema.items():
+        if name not in params:
+            continue
+        if not schema.metadata.get("remove_on_error"):
+            continue
+        if not (schema.is_file_type or schema.is_file_list_type):
+            continue
+
+        if schema.is_file_type:
+            filenames = [params[name]]
+        else:
+            filenames = params[name]
+
+        for path in filenames:
+            if not isinstance(path, str) or not os.path.exists(path):
+                continue
+            try:
+                if os.path.isdir(path) and not os.path.islink(path):
+                    shutil.rmtree(path)
+                    log.warning(f"removed partial output directory '{path}' (remove_on_error)")
+                else:
+                    os.unlink(path)
+                    log.warning(f"removed partial output file '{path}' (remove_on_error)")
+            except OSError as exc:
+                log.error(f"failed to remove '{path}' on error: {exc}")
+
 
 @dataclass
 class Step:
@@ -126,8 +243,13 @@ class Step:
         self.validated_params = None
         # parameters protected from assignment (because they've been set on the command line, presumably)
         self._assignment_overrides = set()
-        if self.skip_if_outputs and self.skip_if_outputs not in (OUTPUTS_EXISTS, OUTPUTS_FRESH):
-            raise StepValidationError(f"step '{self.name}': invalid 'skip_if_outputs={self.skip_if_outputs}' setting")
+        # skip_if_outputs can be "exist", "fresh", or a formula expression
+        # Formulas can reference outputs_exist.X and outputs_fresh.X namespaces
+        if self.skip_if_outputs and self.skip_if_outputs not in _SKIP_MODES:
+            # Treat as a conditional expression -- will be evaluated at runtime
+            self._skip_if_outputs_expr = True
+        else:
+            self._skip_if_outputs_expr = False
         # the "skip" attribute is reevaluated at runtime since it may contain substitutions, but if it's set to a bool
         # constant, self._skip will be preset already
         # validate skip attribute
@@ -618,16 +740,43 @@ class Step:
             elif backend_runner.is_remote_fs:
                 parent_log_info(f"ignoring skip_if_outputs: {skip_if_outputs} because backend has remote filesystem")
                 skip_if_outputs = None
-            # don't check if force-disabled
-            elif (skip_if_outputs == OUTPUTS_EXISTS and stimela.CONFIG.opts.disable_skips.exist) or (
-                skip_if_outputs == OUTPUTS_FRESH and stimela.CONFIG.opts.disable_skips.fresh
-            ):
-                parent_log_info(f"ignoring skip_if_outputs: {skip_if_outputs} because it has been force-disabled")
-                skip_if_outputs = None
+            # don't check if force-disabled (only for legacy "exist"/"fresh" modes)
+            elif not self._skip_if_outputs_expr:
+                if (skip_if_outputs == OUTPUTS_EXISTS and stimela.CONFIG.opts.disable_skips.exist) or (
+                    skip_if_outputs == OUTPUTS_FRESH and stimela.CONFIG.opts.disable_skips.fresh
+                ):
+                    parent_log_info(f"ignoring skip_if_outputs: {skip_if_outputs} because it has been force-disabled")
+                    skip_if_outputs = None
 
-            ## if skip on fresh outputs is in effect, find mtime of most recent input
-            if skip_if_outputs:
-                # max_mtime will remain 0 if we're not echecking for freshness, or if there are no file-type inputs
+            ## Handle skip_if_outputs expression mode (issue #491)
+            if skip_if_outputs and self._skip_if_outputs_expr:
+                parent_log_info(f"evaluating skip_if_outputs expression: {skip_if_outputs}")
+                # Build outputs_exist and outputs_fresh namespace dicts
+                outputs_exist = _check_output_existence(params, self.outputs)
+                outputs_fresh = _check_output_freshness(params, self.inputs, self.outputs)
+                for name, val in outputs_exist.items():
+                    parent_log_info(f"  outputs_exist.{name} = {val}")
+                for name, val in outputs_fresh.items():
+                    parent_log_info(f"  outputs_fresh.{name} = {val}")
+                # Create a copy of subst with the extra namespaces
+                skip_subst = subst.copy() if subst is not None else SubstitutionNS()
+                skip_subst._add_("outputs_exist", outputs_exist, nosubst=True)
+                skip_subst._add_("outputs_fresh", outputs_fresh, nosubst=True)
+                # Evaluate the expression
+                skip_result = evaluate_and_substitute_object(
+                    skip_if_outputs, skip_subst, location=[self.fqname, "skip_if_outputs"], log=self.log
+                )
+                if skip_result is UNSET or isinstance(skip_result, Unresolved):
+                    self.log.debug(f"skip_if_outputs expression returned unresolved: {skip_result}")
+                elif skip_result:
+                    parent_log_info("skip_if_outputs expression evaluated to True, skipping this step")
+                    skip = True
+                else:
+                    parent_log_info("skip_if_outputs expression evaluated to False, proceeding")
+
+            ## Legacy skip_if_outputs mode: "exist" or "fresh"
+            elif skip_if_outputs:
+                # max_mtime will remain 0 if we're not checking for freshness, or if there are no file-type inputs
                 max_mtime, max_mtime_path = 0, None
                 if skip_if_outputs == OUTPUTS_FRESH:
                     parent_log_info("checking if file-type outputs of step are fresh")
@@ -674,7 +823,8 @@ class Step:
                                     continue
                         else:
                             continue  # go on to next parameter
-                        # collect messages rather than logging them directly, to avoid log diarrhea for long file lists
+                        # collect messages rather than logging them directly, to avoid log diarrhea for long file
+                        # lists
                         messages = []
                         # ok, we have a list of files to check
                         for num, value in enumerate(filenames):
@@ -731,21 +881,27 @@ class Step:
                                 else:
                                     os.unlink(path)
 
-                if type(self.cargo) is Recipe:
-                    self.cargo._run(params, subst, backend=backend)
-                elif type(self.cargo) is Cab:
-                    display.set_display_style(backend_opts.current_wrapper or backend_opts.current_backend)
-                    cabstat = backend_runner.run(
-                        self.cargo, params=params, log=self.log, subst=subst, fqname=self.fqname
-                    )
-                    # check for runstate
-                    if cabstat.success is False:
-                        raise StimelaCabRuntimeError(f"error running cab '{self.cargo.name}'", cabstat.errors)
-                    for msg in cabstat.warnings:
-                        self.log.warning(f"cab '{self.cargo.name}': {msg}")
-                    params.update(**cabstat.outputs)
-                else:
-                    raise RuntimeError("step '{self.name}': unknown cargo type")
+                try:
+                    if type(self.cargo) is Recipe:
+                        self.cargo._run(params, subst, backend=backend)
+                    elif type(self.cargo) is Cab:
+                        display.set_display_style(backend_opts.current_wrapper or backend_opts.current_backend)
+                        cabstat = backend_runner.run(
+                            self.cargo, params=params, log=self.log, subst=subst, fqname=self.fqname
+                        )
+                        # check for runstate
+                        if cabstat.success is False:
+                            raise StimelaCabRuntimeError(f"error running cab '{self.cargo.name}'", cabstat.errors)
+                        for msg in cabstat.warnings:
+                            self.log.warning(f"cab '{self.cargo.name}': {msg}")
+                        params.update(**cabstat.outputs)
+                    else:
+                        raise RuntimeError("step '{self.name}': unknown cargo type")
+                except Exception:
+                    # On error, remove outputs marked with remove_on_error (issue #290)
+                    if not backend_runner.is_remote_fs:
+                        _remove_outputs_on_error(params, self.outputs, self.log)
+                    raise
             else:
                 if self._skip is None and subst is not None:
                     parent_log_info("skipping step based on conditonal settings")

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -243,11 +243,15 @@ class Step:
         self.validated_params = None
         # parameters protected from assignment (because they've been set on the command line, presumably)
         self._assignment_overrides = set()
-        # skip_if_outputs can be "exist", "fresh", or a formula expression
-        # Formulas can reference outputs_exist.X and outputs_fresh.X namespaces
+        # skip_if_outputs can be "exist", "fresh", or a formula expression (prefixed with = or containing {})
         if self.skip_if_outputs and self.skip_if_outputs not in _SKIP_MODES:
-            # Treat as a conditional expression -- will be evaluated at runtime
-            self._skip_if_outputs_expr = True
+            if self.skip_if_outputs.startswith("=") or "{" in self.skip_if_outputs:
+                self._skip_if_outputs_expr = True
+            else:
+                raise StepValidationError(
+                    f"step '{self.name}': invalid skip_if_outputs='{self.skip_if_outputs}'. "
+                    f"Expected 'exist', 'fresh', or a formula expression (starting with '=' or containing '{{}}')"
+                )
         else:
             self._skip_if_outputs_expr = False
         # the "skip" attribute is reevaluated at runtime since it may contain substitutions, but if it's set to a bool

--- a/tests/test_issue290_remove_on_error.py
+++ b/tests/test_issue290_remove_on_error.py
@@ -1,0 +1,95 @@
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+from .test_recipe import change_test_dir as change_test_dir
+
+
+def test_remove_outputs_on_error():
+    """Test that _remove_outputs_on_error cleans up files marked with remove_on_error (issue #290)."""
+    from stimela.kitchen.step import _remove_outputs_on_error
+
+    log = MagicMock()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test files
+        file1 = os.path.join(tmpdir, "output1.zarr")
+        os.makedirs(file1)  # directory output (like zarr)
+        file2 = os.path.join(tmpdir, "output2.txt")
+        with open(file2, "w") as f:
+            f.write("test")
+        file3 = os.path.join(tmpdir, "keep_this.txt")
+        with open(file3, "w") as f:
+            f.write("keep")
+
+        assert os.path.exists(file1)
+        assert os.path.exists(file2)
+        assert os.path.exists(file3)
+
+        # Create mock schemas
+        schema_remove_dir = MagicMock()
+        schema_remove_dir.metadata = {"remove_on_error": True}
+        schema_remove_dir.is_file_type = True
+        schema_remove_dir.is_file_list_type = False
+
+        schema_remove_file = MagicMock()
+        schema_remove_file.metadata = {"remove_on_error": True}
+        schema_remove_file.is_file_type = True
+        schema_remove_file.is_file_list_type = False
+
+        schema_keep = MagicMock()
+        schema_keep.metadata = {}
+        schema_keep.is_file_type = True
+        schema_keep.is_file_list_type = False
+
+        outputs_schema = {
+            "zarr-out": schema_remove_dir,
+            "text-out": schema_remove_file,
+            "keep-out": schema_keep,
+        }
+        params = {
+            "zarr-out": file1,
+            "text-out": file2,
+            "keep-out": file3,
+        }
+
+        _remove_outputs_on_error(params, outputs_schema, log)
+
+        # zarr directory should be removed
+        assert not os.path.exists(file1), "Directory with remove_on_error should have been removed"
+        # text file should be removed
+        assert not os.path.exists(file2), "File with remove_on_error should have been removed"
+        # file without remove_on_error should be kept
+        assert os.path.exists(file3), "File without remove_on_error should be kept"
+
+    print("remove_on_error test passed")
+
+
+def test_remove_outputs_on_error_list():
+    """Test remove_on_error with file list-type outputs."""
+    from stimela.kitchen.step import _remove_outputs_on_error
+
+    log = MagicMock()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file1 = os.path.join(tmpdir, "out1.txt")
+        file2 = os.path.join(tmpdir, "out2.txt")
+        with open(file1, "w") as f:
+            f.write("1")
+        with open(file2, "w") as f:
+            f.write("2")
+
+        schema = MagicMock()
+        schema.metadata = {"remove_on_error": True}
+        schema.is_file_type = False
+        schema.is_file_list_type = True
+
+        outputs_schema = {"outputs": schema}
+        params = {"outputs": [file1, file2]}
+
+        _remove_outputs_on_error(params, outputs_schema, log)
+
+        assert not os.path.exists(file1), "List file 1 should be removed"
+        assert not os.path.exists(file2), "List file 2 should be removed"
+
+    print("remove_on_error list test passed")

--- a/tests/test_issue449_slicing.py
+++ b/tests/test_issue449_slicing.py
@@ -1,0 +1,49 @@
+from .test_recipe import change_test_dir as change_test_dir
+from .test_recipe import run, verify_output
+
+
+def test_slice_function():
+    """Test that SLICE() function works for list slicing (issue #449)."""
+    print("===== testing SLICE function =====")
+    retcode, output = run("stimela -v -b native run test_issue449_slicing.yml")
+    assert retcode == 0, f"stimela run failed:\n{output}"
+    print(output)
+    # Check first-n step produces first 3 elements
+    assert verify_output(output, "echo-first-n", "a", "b", "c")
+    # Check mid step produces elements 1-3
+    assert verify_output(output, "echo-mid", "b", "c", "d")
+    # Check to-end step produces elements from index 2 onward
+    assert verify_output(output, "echo-to-end", "c", "d", "e")
+
+
+def test_slice_direct():
+    """Test SLICE function directly via the evaluator."""
+    from scabha.evaluator import Evaluator
+    from scabha.substitutions import SubstitutionNS
+
+    import stimela  # noqa: F401 - ensure patches are applied
+
+    ns = SubstitutionNS(recipe=dict(mylist=["a", "b", "c", "d", "e"]))
+    evaluator = Evaluator(ns, location=["test"])
+
+    # SLICE(list, stop)
+    result = evaluator.evaluate("=SLICE(recipe.mylist, 3)")
+    assert result == ["a", "b", "c"], f"Expected ['a', 'b', 'c'], got {result}"
+
+    # SLICE(list, start, stop)
+    result = evaluator.evaluate("=SLICE(recipe.mylist, 1, 4)")
+    assert result == ["b", "c", "d"], f"Expected ['b', 'c', 'd'], got {result}"
+
+    # SLICE(list, start, UNSET) => list[start:]
+    result = evaluator.evaluate("=SLICE(recipe.mylist, 2, UNSET)")
+    assert result == ["c", "d", "e"], f"Expected ['c', 'd', 'e'], got {result}"
+
+    # SLICE(list, UNSET, stop) => list[:stop]
+    result = evaluator.evaluate("=SLICE(recipe.mylist, UNSET, 2)")
+    assert result == ["a", "b"], f"Expected ['a', 'b'], got {result}"
+
+    # SLICE(list, start, stop, step)
+    result = evaluator.evaluate("=SLICE(recipe.mylist, 0, 5, 2)")
+    assert result == ["a", "c", "e"], f"Expected ['a', 'c', 'e'], got {result}"
+
+    print("All direct SLICE tests passed")

--- a/tests/test_issue449_slicing.yml
+++ b/tests/test_issue449_slicing.yml
@@ -1,0 +1,37 @@
+cabs:
+  echo-list:
+    command: echo
+    inputs:
+      message:
+        dtype: List[str]
+        policies:
+          positional: true
+          repeat: list
+
+recipe:
+  name: test-slicing
+  inputs:
+    mylist:
+      dtype: List[str]
+      default: [a, b, c, d, e]
+    n:
+      dtype: int
+      default: 3
+  steps:
+    # Use SLICE to get first n elements
+    echo-first-n:
+      cab: echo-list
+      params:
+        message: =SLICE(recipe.mylist, recipe.n)
+
+    # Use SLICE with start and stop
+    echo-mid:
+      cab: echo-list
+      params:
+        message: =SLICE(recipe.mylist, 1, 4)
+
+    # Use SLICE with UNSET for omitted start
+    echo-to-end:
+      cab: echo-list
+      params:
+        message: =SLICE(recipe.mylist, 2, UNSET)

--- a/tests/test_issue491_skip_conditionals.py
+++ b/tests/test_issue491_skip_conditionals.py
@@ -1,0 +1,118 @@
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+from .test_recipe import change_test_dir as change_test_dir
+from .test_recipe import run, verify_output
+
+
+def test_skip_expression_outputs_exist():
+    """Test skip_if_outputs with expression using outputs_exist (issue #491)."""
+    os.system("rm -f test_skip_cond[1234].tmp test_skip_cond_input.tmp")
+
+    print("===== all files should be touched =====")
+    retcode, output = run("stimela -b native run test_issue491_skip_conditionals.yml")
+    assert retcode == 0, f"Failed:\n{output}"
+    print(output)
+    assert verify_output(output, "---INVOKING---", "touch test_skip_cond1.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_skip_cond2.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_skip_cond3.tmp")
+    assert verify_output(output, "---INVOKING---", "touch test_skip_cond4.tmp")
+
+    print("===== steps 1, 2, 4 should be skipped (outputs exist) =====")
+    retcode, output = run("stimela -b native run test_issue491_skip_conditionals.yml")
+    assert retcode == 0, f"Failed:\n{output}"
+    print(output)
+    # touch1 uses legacy "exist" mode
+    assert not verify_output(output, "---INVOKING---", "touch test_skip_cond1.tmp")
+    # touch2 uses expression mode with outputs_exist
+    assert not verify_output(output, "---INVOKING---", "touch test_skip_cond2.tmp")
+    # touch3 uses freshness check -- outputs should be fresh after first run
+    assert not verify_output(output, "---INVOKING---", "touch test_skip_cond3.tmp")
+    # touch4 uses expression mode with outputs_exist
+    assert not verify_output(output, "---INVOKING---", "touch test_skip_cond4.tmp")
+
+    print("===== cleaning up =====")
+    os.system("rm -f test_skip_cond[1234].tmp test_skip_cond_input.tmp")
+
+
+def test_check_output_existence():
+    """Test _check_output_existence helper function."""
+    from stimela.kitchen.step import _check_output_existence
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        existing = os.path.join(tmpdir, "exists.txt")
+        missing = os.path.join(tmpdir, "missing.txt")
+        with open(existing, "w") as f:
+            f.write("test")
+
+        schema_file = MagicMock()
+        schema_file.is_file_type = True
+        schema_file.is_file_list_type = False
+
+        schema_missing = MagicMock()
+        schema_missing.is_file_type = True
+        schema_missing.is_file_list_type = False
+
+        outputs = {"out1": schema_file, "out2": schema_missing}
+        params = {"out1": existing, "out2": missing}
+
+        result = _check_output_existence(params, outputs)
+        assert result["out1"] is True, "Existing file should return True"
+        assert result["out2"] is False, "Missing file should return False"
+
+    print("_check_output_existence test passed")
+
+
+def test_check_output_freshness():
+    """Test _check_output_freshness helper function."""
+    import time
+
+    from stimela.kitchen.step import _check_output_freshness
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create an input file
+        infile = os.path.join(tmpdir, "input.txt")
+        with open(infile, "w") as f:
+            f.write("input")
+
+        time.sleep(0.05)
+
+        # Create a fresh output (newer than input)
+        fresh_out = os.path.join(tmpdir, "fresh_output.txt")
+        with open(fresh_out, "w") as f:
+            f.write("fresh")
+
+        # Set a stale output (older than input) by backdating it
+        stale_out = os.path.join(tmpdir, "stale_output.txt")
+        with open(stale_out, "w") as f:
+            f.write("stale")
+        # Set mtime to 1 second before input
+        input_mtime = os.path.getmtime(infile)
+        os.utime(stale_out, (input_mtime - 1, input_mtime - 1))
+
+        input_schema = MagicMock()
+        input_schema.is_input = True
+        input_schema.is_file_type = True
+        input_schema.is_file_list_type = False
+        input_schema.skip_freshness_checks = False
+
+        fresh_schema = MagicMock()
+        fresh_schema.is_file_type = True
+        fresh_schema.is_file_list_type = False
+        fresh_schema.skip_freshness_checks = False
+
+        stale_schema = MagicMock()
+        stale_schema.is_file_type = True
+        stale_schema.is_file_list_type = False
+        stale_schema.skip_freshness_checks = False
+
+        inputs = {"infile": input_schema}
+        outputs = {"fresh": fresh_schema, "stale": stale_schema}
+        params = {"infile": infile, "fresh": fresh_out, "stale": stale_out}
+
+        result = _check_output_freshness(params, inputs, outputs)
+        assert result["fresh"] is True, "Fresh output should return True"
+        assert result["stale"] is False, "Stale output should return False"
+
+    print("_check_output_freshness test passed")

--- a/tests/test_issue491_skip_conditionals.py
+++ b/tests/test_issue491_skip_conditionals.py
@@ -8,7 +8,11 @@ from .test_recipe import run, verify_output
 
 def test_skip_expression_outputs_exist():
     """Test skip_if_outputs with expression using outputs_exist (issue #491)."""
-    os.system("rm -f test_skip_cond[1234].tmp test_skip_cond_input.tmp")
+    os.system("rm -f test_skip_cond[1234].tmp test_skip_cond4b.tmp test_skip_cond_input.tmp")
+
+    # Create input file for freshness test (touch3 needs it to compare mtimes)
+    with open("test_skip_cond_input.tmp", "w") as f:
+        f.write("input")
 
     print("===== all files should be touched =====")
     retcode, output = run("stimela -b native run test_issue491_skip_conditionals.yml")
@@ -29,11 +33,11 @@ def test_skip_expression_outputs_exist():
     assert not verify_output(output, "---INVOKING---", "touch test_skip_cond2.tmp")
     # touch3 uses freshness check -- outputs should be fresh after first run
     assert not verify_output(output, "---INVOKING---", "touch test_skip_cond3.tmp")
-    # touch4 uses expression mode with outputs_exist
+    # touch4 uses compound AND expression with outputs_exist
     assert not verify_output(output, "---INVOKING---", "touch test_skip_cond4.tmp")
 
     print("===== cleaning up =====")
-    os.system("rm -f test_skip_cond[1234].tmp test_skip_cond_input.tmp")
+    os.system("rm -f test_skip_cond[1234].tmp test_skip_cond4b.tmp test_skip_cond_input.tmp")
 
 
 def test_check_output_existence():

--- a/tests/test_issue491_skip_conditionals.yml
+++ b/tests/test_issue491_skip_conditionals.yml
@@ -12,6 +12,17 @@ cabs:
         dtype: File
         policies:
           positional: true
+  touch-two:
+    command: touch
+    outputs:
+      file1:
+        dtype: File
+        policies:
+          positional: true
+      file2:
+        dtype: File
+        policies:
+          positional: true
 
 recipe:
   name: test-skip-conditionals
@@ -40,7 +51,8 @@ recipe:
 
     # Expression mode with AND: skip only if BOTH outputs exist
     touch4:
-      cab: touch
+      cab: touch-two
       params:
-        file: test_skip_cond4.tmp
-      skip_if_outputs: =outputs_exist.file
+        file1: test_skip_cond4.tmp
+        file2: test_skip_cond4b.tmp
+      skip_if_outputs: =outputs_exist.file1 and outputs_exist.file2

--- a/tests/test_issue491_skip_conditionals.yml
+++ b/tests/test_issue491_skip_conditionals.yml
@@ -1,0 +1,46 @@
+cabs:
+  touch:
+    command: touch
+    inputs:
+      conditional-file:
+        dtype: File
+        must_exist: false
+        policies:
+          skip: true  # not passed to command
+    outputs:
+      file:
+        dtype: File
+        policies:
+          positional: true
+
+recipe:
+  name: test-skip-conditionals
+  steps:
+    # Legacy mode: skip if output exists
+    touch1:
+      cab: touch
+      params:
+        file: test_skip_cond1.tmp
+      skip_if_outputs: exist
+
+    # Expression mode: skip if output exists (using outputs_exist namespace)
+    touch2:
+      cab: touch
+      params:
+        file: test_skip_cond2.tmp
+      skip_if_outputs: =outputs_exist.file
+
+    # Expression mode: skip if output is fresh
+    touch3:
+      cab: touch
+      params:
+        conditional-file: test_skip_cond_input.tmp
+        file: test_skip_cond3.tmp
+      skip_if_outputs: =outputs_fresh.file
+
+    # Expression mode with AND: skip only if BOTH outputs exist
+    touch4:
+      cab: touch
+      params:
+        file: test_skip_cond4.tmp
+      skip_if_outputs: =outputs_exist.file


### PR DESCRIPTION
## Summary

Fixes three issues from the R2.3 milestone:

- **#491 - skip_if_outputs needs conditionals**: `skip_if_outputs` now accepts formula expressions (not just `"exist"` / `"fresh"`). Expressions can reference `outputs_exist.<param>` and `outputs_fresh.<param>` namespace lookups that report whether each file-type output exists or is fresh relative to inputs. Example: `skip_if_outputs: =outputs_exist.outfile and outputs_fresh.outfile`. The legacy `exist`/`fresh` string modes continue to work unchanged.

- **#290 - Add remove_on_error option to outputs**: Outputs with `metadata: {remove_on_error: true}` in their parameter schema are automatically cleaned up (file deleted, directory tree removed) when the step fails. This prevents partial zarr outputs from passing freshness checks on re-run. Since `Parameter` is defined in the external `scabha` package, the field is carried via the existing `metadata` dict rather than a new dataclass field.

- **#449 - Cannot index n elements from a list (slicing)**: Adds a `SLICE()` function to the expression evaluator via monkey-patch of scabha's `FunctionHandler`. Supports `SLICE(list, stop)`, `SLICE(list, start, stop)`, and `SLICE(list, start, stop, step)`. Use `UNSET` for omitted components (e.g. `SLICE(mylist, UNSET, 5)` for `mylist[:5]`). Native Python slice syntax (`list[:n]`) requires grammar changes in scabha upstream; `SLICE()` provides equivalent functionality in the meantime.

## Test plan

- [x] `tests/test_issue449_slicing.py` - integration and unit tests for SLICE function
- [x] `tests/test_issue290_remove_on_error.py` - unit tests for remove_on_error cleanup
- [x] `tests/test_issue491_skip_conditionals.py` - integration and unit tests for skip expression evaluation
- [x] Full test suite passes (72/72, excluding pre-existing `test_test_recipe` failure)

Closes #491, closes #290, closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)