### PR TITLE
Fix CLI assignment errors and boolean flag handling

### DIFF
--- a/stimela/kitchen/cab.py
+++ b/stimela/kitchen/cab.py
@@ -388,11 +388,18 @@ class Cab(Cargo):
                 strval = str(value) if explicit is None else str(explicit)
                 if key_value:
                     args += [f"{option}={strval}"]
-                # in option mode, use --option value for explicit settings,
-                # else give option for True and omit for False. TODO: some tools may eventually need a policy for
-                # passing --no-option for False.
+                # in option mode, use --option value for explicit settings
+                elif explicit is not None:
+                    args += [option, strval]
+                # explicit_flag policy: emit --no-<name> for False (dual-flag mode, as in clickify_parameters)
+                elif get_policy(schema, "explicit_flag"):
+                    if value:
+                        args += [option]
+                    else:
+                        args += [prefix + "no-" + (schema.nom_de_guerre or name)]
+                # default: give option for True, omit for False
                 else:
-                    args += [option, strval] if explicit is not None else ([option] if value else [])
+                    args += [option] if value else []
             else:
                 value = stringify_argument(name, value, schema, option=option)
                 if type(value) is list:

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -340,7 +340,8 @@ class Recipe(Cargo):
                 self.inputs_outputs[key].default = UNSET
             else:
                 self.defaults[key] = value
-        # assigning to a substep? Invoke nested assignment
+        # assigning to a substep? Invoke nested assignment (and return, as the
+        # step handles its own override tracking)
         elif nesting is not None and nesting in self.steps:
             return self.steps[nesting].assign_value(subkey, value, override=override)
         # assigning to config?
@@ -356,6 +357,11 @@ class Recipe(Cargo):
             whose.update_log_options(**{subkey: value})
             if whose is self and subst is not None and "recipe" in subst:
                 subst.recipe.log[subkey] = value
+        elif override:
+            # in override mode (i.e. from CLI or parameter file), reject unknown variables
+            raise AssignmentError(
+                f"'{key}' is not a known input, output, step, or config variable of recipe '{self.fqname}'"
+            )
         # in override mode, assign to assign dict for future processing
         if override:
             if value is not UNSET:

--- a/tests/test_bool_flags.yml
+++ b/tests/test_bool_flags.yml
@@ -1,0 +1,49 @@
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime}
+    nest: 3
+    symlink: logs
+
+cabs:
+  bool_test:
+    command: echo
+    inputs:
+      # default behavior: --flag for True, omit for False
+      default-flag:
+        dtype: bool
+      # is_flag policy: same as default (--flag for True, omit for False)
+      is-flag-param:
+        dtype: bool
+        policies:
+          is_flag: true
+      # explicit_flag policy: --flag for True, --no-flag for False
+      dual-flag:
+        dtype: bool
+        policies:
+          explicit_flag: true
+      # explicit_true/explicit_false: custom values
+      explicit-param:
+        dtype: bool
+        policies:
+          explicit_true: "yes"
+          explicit_false: "no"
+
+test-bool-flags-true:
+  steps:
+    s1:
+      cab: bool_test
+      params:
+        default-flag: true
+        is-flag-param: true
+        dual-flag: true
+        explicit-param: true
+
+test-bool-flags-false:
+  steps:
+    s1:
+      cab: bool_test
+      params:
+        default-flag: false
+        is-flag-param: false
+        dual-flag: false
+        explicit-param: false

--- a/tests/test_cli_assign.yml
+++ b/tests/test_cli_assign.yml
@@ -1,0 +1,34 @@
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime}
+    nest: 3
+    symlink: logs
+
+cabs:
+  echo_params:
+    flavour: python-code
+    command: |
+      print(f"x={x}, y={y}")
+    inputs:
+      x:
+        dtype: str
+      y:
+        dtype: str
+        default: "default_y"
+
+test-cli-assign:
+  inputs:
+    x:
+      dtype: str
+      required: true
+    y:
+      dtype: str
+      default: "default_y"
+  assign:
+    internal_var: "some_value"
+  steps:
+    echo:
+      cab: echo_params
+      params:
+        x: =recipe.x
+        y: =recipe.y

--- a/tests/test_cli_issues.py
+++ b/tests/test_cli_issues.py
@@ -1,0 +1,65 @@
+"""Tests for CLI/parameter issues #490 and #438."""
+
+from .test_recipe import change_test_dir as change_test_dir
+from .test_recipe import run, verify_output
+
+# === Issue #490: assigning foo=bar from CLI only works if foo is a proper input ===
+
+
+def test_cli_assign_valid_input():
+    """Valid input assignment from CLI should succeed."""
+    retcode, output = run("stimela -v -b native exec test_cli_assign.yml test-cli-assign x=hello")
+    assert retcode == 0
+    assert verify_output(output, "x=hello")
+
+
+def test_cli_assign_valid_step_param():
+    """Assignment to a step parameter (step.param=value) should succeed."""
+    retcode, output = run("stimela -v -b native exec test_cli_assign.yml test-cli-assign x=hello echo.y=world")
+    assert retcode == 0
+    assert verify_output(output, "x=hello, y=world")
+
+
+def test_cli_assign_unknown_variable():
+    """Assignment to an unknown variable should produce a clear error."""
+    retcode, output = run("stimela -v -b native exec test_cli_assign.yml test-cli-assign x=hello nonexistent=bar")
+    assert retcode != 0
+    assert verify_output(output, "not a known input")
+
+
+def test_cli_assign_typo_in_input_name():
+    """A typo in an input name should produce a clear error, not be silently ignored."""
+    retcode, output = run("stimela -v -b native exec test_cli_assign.yml test-cli-assign xx=hello")
+    assert retcode != 0
+    assert verify_output(output, "not a known input")
+
+
+# === Issue #438: more elegant handling of boolean flags ===
+
+
+def test_bool_flags_true():
+    """Boolean flags set to True should produce correct command-line arguments."""
+    retcode, output = run("stimela -v -b native exec test_bool_flags.yml test-bool-flags-true")
+    assert retcode == 0
+    # All True: should have --default-flag, --is-flag-param, --dual-flag, --explicit-param yes
+    assert verify_output(output, "--default-flag")
+    assert verify_output(output, "--is-flag-param")
+    assert verify_output(output, "--dual-flag")
+    assert verify_output(output, "--explicit-param yes")
+
+
+def test_bool_flags_false():
+    """Boolean flags set to False should produce correct command-line arguments.
+    In particular, explicit_flag policy should emit --no-<name> for False values.
+    """
+    retcode, output = run("stimela -v -b native exec test_bool_flags.yml test-bool-flags-false")
+    assert retcode == 0
+    # default-flag=False: should be omitted (no --default-flag in output)
+    # is-flag-param=False: should be omitted (no --is-flag-param)
+    # dual-flag=False with explicit_flag: should produce --no-dual-flag
+    assert verify_output(output, "--no-dual-flag")
+    # explicit-param=False with explicit_false="no": should produce --explicit-param no
+    assert verify_output(output, "--explicit-param no")
+    # Verify that default-flag and is-flag-param are NOT in the command line
+    assert not verify_output(output, "--default-flag")
+    assert not verify_output(output, "--is-flag-param")


### PR DESCRIPTION
## Summary

- **#490**: CLI/parameter-file assignments to unknown variables (not an input, output, step, config, or log variable) now raise a clear `AssignmentError` instead of being silently discarded. This catches typos and prevents user-baffling errors when a variable name doesn't match anything in the recipe.
- **#438**: Added support for `--no-<flag>` boolean flag handling via the `explicit_flag` policy. When a cab parameter has `policies: { explicit_flag: true }`, the command-line builder emits `--<name>` for True and `--no-<name>` for False, matching the dual-flag pattern from `clickify_parameters` in scabha.

Closes #490
Closes #438

## Changes

- `stimela/kitchen/recipe.py`: Added `elif override:` branch in `assign_value()` that raises `AssignmentError` when a CLI/parameter-file assignment doesn't match any known recipe target.
- `stimela/kitchen/cab.py`: Restructured boolean flag handling in `build_argument_list()` to check the `explicit_flag` policy. When set, emits `--no-<name>` for False values using the same prefix as the positive form.
- `tests/test_cli_issues.py`: 6 new tests covering both issues.
- `tests/test_cli_assign.yml`: Test recipe for CLI assignment validation.
- `tests/test_bool_flags.yml`: Test recipe for boolean flag command-line construction.

## Test plan

- [x] `test_cli_assign_valid_input` - Valid input assignment succeeds
- [x] `test_cli_assign_valid_step_param` - Step-level assignment (step.param=value) succeeds
- [x] `test_cli_assign_unknown_variable` - Unknown variable assignment produces clear error
- [x] `test_cli_assign_typo_in_input_name` - Typo in input name produces clear error
- [x] `test_bool_flags_true` - All boolean policies produce correct args for True
- [x] `test_bool_flags_false` - explicit_flag emits --no-flag, default omits, explicit_false uses custom value
- [x] Existing tests pass (aliasing, nesting, loop recipes, callables, param files, conditional skips, backends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)