### PR TITLE
Fix for-loop prevalidation with step-level assignments (#282)

### DIFF
--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -827,9 +827,15 @@ class Recipe(Cargo):
             self.log, self.logopts, nesting=self.nesting, subst=subst, location=[self.fqname]
         )
 
-        # add for-loop variable to inputs, if expected there
-        if self.for_loop is not None and self.for_loop.var in self.inputs:
-            params[self.for_loop.var] = Placeholder(self.for_loop.var)
+        # add for-loop variable as a placeholder during prevalidation
+        if self.for_loop is not None:
+            placeholder = Placeholder(self.for_loop.var)
+            # add to inputs if expected there
+            if self.for_loop.var in self.inputs:
+                params[self.for_loop.var] = placeholder
+            # always add to subst namespace so step-level assignments
+            # referencing =recipe.<var> can resolve during prevalidation
+            subst.recipe._add_(self.for_loop.var, placeholder)
 
         # prevalidate our own parameters. This substitutes in defaults and does {}-substitutions
         # we call this twice, potentially, so define as a function

--- a/tests/test_forloop_assign.yml
+++ b/tests/test_forloop_assign.yml
@@ -1,0 +1,35 @@
+## Test for issue #282: For-loops and step-level assignments fail prevalidation
+## When a for-loop variable is used inside a step-level assignment, prevalidation
+## should not fail because the loop variable is UNSET at prevalidation time.
+
+cabs:
+  echo_cab:
+    command: echo
+    inputs:
+      msg:
+        dtype: str
+        required: true
+      num:
+        dtype: int
+        default: 0
+
+forloop_step_assign:
+  name: "forloop_step_assign"
+
+  for_loop:
+    var: nnodes
+    over: [1,2,3]
+
+  steps:
+    echo1:
+      cab: echo_cab
+      assign:
+        num: =recipe.nnodes
+      params:
+        msg: "hello"
+
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime}
+    nest: 3
+    symlink: logs

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -149,6 +149,15 @@ def test_issue527_3():
     assert verify_output(output, "invalid inputs")
 
 
+def test_forloop_step_assign():
+    """Test that for-loop variables can be used in step-level assignments.
+    Regression test for https://github.com/caracal-pipeline/stimela/issues/282
+    """
+    print("===== expecting no errors: for-loop var used in step assign =====")
+    retcode, output = run("stimela -v -b native exec test_forloop_assign.yml forloop_step_assign")
+    assert retcode == 0, f"For-loop step-level assignment failed: {output}"
+
+
 def test_scatter():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml basic_loop")


### PR DESCRIPTION
## Summary
- Fixes #282: For-loop variables can now be used in step-level assignments without failing prevalidation. The for-loop variable is added as a `Placeholder` to the `subst.recipe` namespace before step prevalidation, so that expressions like `=recipe.nnodes` can resolve.

**Note:** The scabha-side fixes for #293, #265, and #404 are in a separate PR on the scabha repo: https://github.com/caracal-pipeline/scabha/pull/26. Once that PR is merged and a new scabha version is released, the stimela dependency should be updated.

## Test plan
- [x] Added `test_forloop_step_assign` test with `test_forloop_assign.yml` that exercises a for-loop variable in a step-level assignment
- [x] Existing `test_test_loop_recipe` test still passes
- [x] All 59 non-recipe tests pass
- [x] All recipe tests pass except `test_test_recipe` (pre-existing failure due to `/bin/true` not existing on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)