### PR TITLE
Remove dead allow-direct-references setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,6 @@ dependencies = [
     "psutil>=5.9,<7"
 ]
 
-[tool.hatch.metadata]
-allow-direct-references = true # Remove when divorce is complete
-
 
 [project.scripts]
 stimela = "stimela.main:cli"


### PR DESCRIPTION
## Summary
- Removes the `[tool.hatch.metadata] allow-direct-references = true` setting from `pyproject.toml`
- This setting was needed when scabha was installed via a `git+https` URL, but scabha has been a proper PyPI dependency (`scabha>=2.2.0rc0`) since the scabha/stimela divorce was completed
- The comment on the line itself said "Remove when divorce is complete" -- the divorce is complete

Closes #547

## Test plan
- [ ] Verify `uv sync` still works without the setting
- [ ] Verify package builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)