### PR TITLE
Handle missing metrics server gracefully in kube backend

### DIFF
--- a/stimela/backends/kube/kube_utils.py
+++ b/stimela/backends/kube/kube_utils.py
@@ -241,7 +241,8 @@ class StatusReporter(object):
                     )
                 except ApiException as exc:
                     self.report_api_error("metrics.k8s.io", exc)
-                    self.enable_metrics = False
+                    if exc.status in (404, 403):
+                        self.enable_metrics = False
         except (ConnectionError, HTTPError):
             self.connected = False
             # self.log.warning(f"disconnected: {exc}")

--- a/stimela/backends/kube/kube_utils.py
+++ b/stimela/backends/kube/kube_utils.py
@@ -241,6 +241,7 @@ class StatusReporter(object):
                     )
                 except ApiException as exc:
                     self.report_api_error("metrics.k8s.io", exc)
+                    self.enable_metrics = False
         except (ConnectionError, HTTPError):
             self.connected = False
             # self.log.warning(f"disconnected: {exc}")

--- a/stimela/display/styles/kube.py
+++ b/stimela/display/styles/kube.py
@@ -159,19 +159,26 @@ class KubeDisplay(DisplayStyle):
 
         self.kube_connection_status.update(self.kube_connection_status_id, value=f"{report.connection_status}")
 
-        cpu_percent = report.total_cores * 100
+        if report.total_cores is not None:
+            cpu_percent = report.total_cores * 100
+            self.kube_core_usage.update(self.kube_core_usage_id, value=f"[green]{cpu_percent:2.1f}[/green]%")
+            max_cpu_percent = max(cpu_percent, self.task_maxima["kube_peak_core_usage"])
+            self.task_maxima["kube_peak_core_usage"] = max_cpu_percent
+            self.kube_peak_core_usage.update(
+                self.kube_peak_core_usage_id, value=f"[green]{max_cpu_percent:2.1f}[/green]%"
+            )
+        else:
+            self.kube_core_usage.update(self.kube_core_usage_id, value="[dim]N/A[/dim]")
+            self.kube_peak_core_usage.update(self.kube_peak_core_usage_id, value="[dim]N/A[/dim]")
 
-        self.kube_core_usage.update(self.kube_core_usage_id, value=f"[green]{cpu_percent:2.1f}[/green]%")
-
-        max_cpu_percent = max(cpu_percent, self.task_maxima["kube_peak_core_usage"])
-        self.task_maxima["kube_peak_core_usage"] = max_cpu_percent
-        self.kube_peak_core_usage.update(self.kube_peak_core_usage_id, value=f"[green]{max_cpu_percent:2.1f}[/green]%")
-
-        self.kube_ram_usage.update(self.kube_ram_usage_id, value=f"[green]{report.total_memory}[/green]GB")
-
-        max_ram = max(report.total_memory, self.task_maxima["kube_peak_ram_usage"])
-        self.task_maxima["kube_peak_ram_usage"] = max_ram
-        self.kube_peak_ram_usage.update(self.kube_peak_ram_usage_id, value=f"[green]{max_ram}[/green]GB")
+        if report.total_memory is not None:
+            self.kube_ram_usage.update(self.kube_ram_usage_id, value=f"[green]{report.total_memory}[/green]GB")
+            max_ram = max(report.total_memory, self.task_maxima["kube_peak_ram_usage"])
+            self.task_maxima["kube_peak_ram_usage"] = max_ram
+            self.kube_peak_ram_usage.update(self.kube_peak_ram_usage_id, value=f"[green]{max_ram}[/green]GB")
+        else:
+            self.kube_ram_usage.update(self.kube_ram_usage_id, value="[dim]N/A[/dim]")
+            self.kube_peak_ram_usage.update(self.kube_peak_ram_usage_id, value="[dim]N/A[/dim]")
 
         self.pending_pods.update(self.pending_pods_id, value=f"[yellow]{report.pending_pods}[/yellow]")
         self.running_pods.update(self.running_pods_id, value=f"[green]{report.running_pods}[/green]")
@@ -280,9 +287,18 @@ class SimpleKubeDisplay(DisplayStyle):
             return
 
         self.kube_connection_status.update(self.kube_connection_status_id, value=f"{report.connection_status}")
-        cpu_percent = report.total_cores * 100
-        self.kube_core_usage.update(self.kube_core_usage_id, value=f"[green]{cpu_percent:2.1f}[/green]%")
-        self.kube_ram_usage.update(self.kube_ram_usage_id, value=f"[green]{report.total_memory}[/green]GB")
+
+        if report.total_cores is not None:
+            cpu_percent = report.total_cores * 100
+            self.kube_core_usage.update(self.kube_core_usage_id, value=f"[green]{cpu_percent:2.1f}[/green]%")
+        else:
+            self.kube_core_usage.update(self.kube_core_usage_id, value="[dim]N/A[/dim]")
+
+        if report.total_memory is not None:
+            self.kube_ram_usage.update(self.kube_ram_usage_id, value=f"[green]{report.total_memory}[/green]GB")
+        else:
+            self.kube_ram_usage.update(self.kube_ram_usage_id, value="[dim]N/A[/dim]")
+
         self.pending_pods.update(self.pending_pods_id, value=f"[yellow]{report.pending_pods}[/yellow]")
         self.running_pods.update(self.running_pods_id, value=f"[cyan]{report.running_pods}[/cyan]")
         self.successful_pods.update(self.successful_pods_id, value=f"[green]{report.successful_pods}[/green]")

--- a/stimela/monitoring/kube.py
+++ b/stimela/monitoring/kube.py
@@ -21,4 +21,9 @@ class KubeReport:
 
     @property
     def profiling_results(self):
-        return {"k8s_cores": self.total_cores, "k8s_mem": self.total_memory}
+        results = {}
+        if self.total_cores is not None:
+            results["k8s_cores"] = self.total_cores
+        if self.total_memory is not None:
+            results["k8s_mem"] = self.total_memory
+        return results

--- a/tests/test_kube_metrics.py
+++ b/tests/test_kube_metrics.py
@@ -155,3 +155,33 @@ class TestStatusReporterMetricsDisable:
             mock_custom_api.list_namespaced_custom_object.reset_mock()
             report = statrep.update()
             mock_custom_api.list_namespaced_custom_object.assert_not_called()
+
+    def test_metrics_not_disabled_on_transient_5xx(self):
+        from unittest.mock import patch
+
+        from kubernetes.client.rest import ApiException
+
+        with patch("stimela.backends.kube.kube_utils.get_kube_api") as mock_get_kube_api:
+            from stimela.backends.kube.kube_utils import StatusReporter
+
+            mock_kube_api = MagicMock()
+            mock_custom_api = MagicMock()
+            mock_get_kube_api.return_value = ("default", mock_kube_api, mock_custom_api)
+
+            mock_kube_api.list_namespaced_event.return_value = MagicMock(items=[])
+            mock_kube_api.list_namespaced_pod.return_value = MagicMock(items=[])
+            mock_custom_api.list_namespaced_custom_object.side_effect = ApiException(
+                status=503, reason="Service Unavailable"
+            )
+
+            kube = MagicMock()
+            kube.debug.log_events = False
+            log = MagicMock()
+
+            statrep = StatusReporter(podname="test-pod", log=log, kube=kube, event_handler=None)
+            assert statrep.enable_metrics is True
+
+            report = statrep.update()
+            assert statrep.enable_metrics is True
+            assert report.total_cores is None
+            assert report.total_memory is None

--- a/tests/test_kube_metrics.py
+++ b/tests/test_kube_metrics.py
@@ -1,0 +1,157 @@
+"""Tests for graceful degradation when kube metrics server is unavailable."""
+
+import importlib.util
+from unittest.mock import MagicMock
+
+import pytest
+from rich.progress import Progress
+
+from stimela.monitoring.kube import KubeReport
+
+HAS_KUBERNETES = importlib.util.find_spec("kubernetes") is not None
+
+
+class TestKubeReportWithoutMetrics:
+    """Test that KubeReport handles None metrics values correctly."""
+
+    def test_default_report_has_none_metrics(self):
+        report = KubeReport()
+        assert report.total_cores is None
+        assert report.total_memory is None
+
+    def test_profiling_results_omits_none_values(self):
+        report = KubeReport()
+        assert report.profiling_results == {}
+
+    def test_profiling_results_includes_cores_when_present(self):
+        report = KubeReport(total_cores=2.5)
+        result = report.profiling_results
+        assert result == {"k8s_cores": 2.5}
+
+    def test_profiling_results_includes_memory_when_present(self):
+        report = KubeReport(total_memory=16.0)
+        result = report.profiling_results
+        assert result == {"k8s_mem": 16.0}
+
+    def test_profiling_results_includes_both_when_present(self):
+        report = KubeReport(total_cores=4.0, total_memory=32.0)
+        result = report.profiling_results
+        assert result == {"k8s_cores": 4.0, "k8s_mem": 32.0}
+
+
+class TestKubeDisplayWithoutMetrics:
+    """Test that kube display classes handle None metrics gracefully."""
+
+    def _make_display(self, cls):
+        run_timer = Progress()
+        run_timer.add_task("")
+        display = cls.__new__(cls)
+        display.run_elapsed = run_timer
+        display.run_elapsed_id = 0
+        display.__init__(run_timer)
+        return display
+
+    def test_kube_display_handles_none_metrics(self):
+        from stimela.display.styles.kube import KubeDisplay
+
+        display = self._make_display(KubeDisplay)
+        report = KubeReport(
+            running_pods=1,
+            pending_pods=0,
+            terminating_pods=0,
+            successful_pods=0,
+            failed_pods=0,
+            stateless_pods=0,
+            total_pods=1,
+            total_cores=None,
+            total_memory=None,
+        )
+        display.update(None, report)
+
+    def test_kube_display_handles_present_metrics(self):
+        from stimela.display.styles.kube import KubeDisplay
+
+        display = self._make_display(KubeDisplay)
+        report = KubeReport(
+            running_pods=1,
+            pending_pods=0,
+            terminating_pods=0,
+            successful_pods=0,
+            failed_pods=0,
+            stateless_pods=0,
+            total_pods=1,
+            total_cores=2.5,
+            total_memory=8.0,
+        )
+        display.update(None, report)
+
+    def test_simple_kube_display_handles_none_metrics(self):
+        from stimela.display.styles.kube import SimpleKubeDisplay
+
+        display = self._make_display(SimpleKubeDisplay)
+        report = KubeReport(
+            running_pods=1,
+            pending_pods=0,
+            successful_pods=0,
+            failed_pods=0,
+            total_cores=None,
+            total_memory=None,
+        )
+        display.update(None, report)
+
+    def test_simple_kube_display_handles_present_metrics(self):
+        from stimela.display.styles.kube import SimpleKubeDisplay
+
+        display = self._make_display(SimpleKubeDisplay)
+        report = KubeReport(
+            running_pods=1,
+            pending_pods=0,
+            successful_pods=0,
+            failed_pods=0,
+            total_cores=4.0,
+            total_memory=16.0,
+        )
+        display.update(None, report)
+
+    def test_kube_display_non_kube_report_is_noop(self):
+        from stimela.display.styles.kube import KubeDisplay
+
+        display = self._make_display(KubeDisplay)
+        display.update(None, "not a KubeReport")
+
+
+@pytest.mark.skipif(not HAS_KUBERNETES, reason="kubernetes package not installed")
+class TestStatusReporterMetricsDisable:
+    """Test that StatusReporter disables metrics after API failure."""
+
+    def test_metrics_disabled_after_api_error(self):
+        from unittest.mock import patch
+
+        from kubernetes.client.rest import ApiException
+
+        with patch("stimela.backends.kube.kube_utils.get_kube_api") as mock_get_kube_api:
+            from stimela.backends.kube.kube_utils import StatusReporter
+
+            mock_kube_api = MagicMock()
+            mock_custom_api = MagicMock()
+            mock_get_kube_api.return_value = ("default", mock_kube_api, mock_custom_api)
+
+            mock_kube_api.list_namespaced_event.return_value = MagicMock(items=[])
+            mock_kube_api.list_namespaced_pod.return_value = MagicMock(items=[])
+            mock_custom_api.list_namespaced_custom_object.side_effect = ApiException(status=404, reason="Not Found")
+
+            kube = MagicMock()
+            kube.debug.log_events = False
+            log = MagicMock()
+
+            statrep = StatusReporter(podname="test-pod", log=log, kube=kube, event_handler=None)
+            assert statrep.enable_metrics is True
+
+            report = statrep.update()
+            assert statrep.enable_metrics is False
+            assert report.total_cores is None
+            assert report.total_memory is None
+
+            mock_custom_api.list_namespaced_custom_object.reset_mock()
+            report = statrep.update()
+            mock_custom_api.list_namespaced_custom_object.assert_not_called()


### PR DESCRIPTION
## Summary
- Fixes crash when kube metrics server is absent by handling `None` values in `KubeReport`
- `StatusReporter` disables metrics collection after the first API failure to avoid repeated error spam
- `KubeDisplay` and `SimpleKubeDisplay` show "N/A" for CPU/RAM when metrics are unavailable
- `KubeReport.profiling_results` omits `None` values to prevent `TypeError` in stat aggregation

Closes #504

## Test plan
- [x] Added `tests/test_kube_metrics.py` with tests for:
  - `KubeReport` with `None` metrics (profiling_results filtering)
  - Both display classes handling `None` metrics without crashing
  - Both display classes handling present metrics correctly
  - `StatusReporter` disabling metrics after API failure (skipped when kubernetes not installed)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)