### PR TITLE
Reject unknown parameters passed via CLI

### DIFF
--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -584,25 +584,39 @@ def run(
                 log.debug(line)
             sys.exit(1)
 
-        for key, value in params.items():
-            try:
-                recipe.assign_value(key, value, override=True)
-            except ScabhaBaseException as exc:
-                log_exception(exc)
-                sys.exit(1)
+        # check for unknown parameters before applying CLI overrides
+        def _flatten_assign_keys(d, prefix=""):
+            keys = set()
+            for k, v in d.items():
+                full = f"{prefix}{k}"
+                if isinstance(v, (dict, OrderedDict, DictConfig)):
+                    keys.update(_flatten_assign_keys(v, f"{full}."))
+                else:
+                    keys.add(full)
+            return keys
 
-        # create subst namespace for outer step
-
-        # check for unknown parameters: params that are not inputs/outputs and not
-        # valid nested assignments (step.param, config.xxx, log.xxx)
+        assign_keys = _flatten_assign_keys(recipe.assign) if recipe.assign else set()
+        log_fields = set(recipe.logopts) if hasattr(recipe, "logopts") and recipe.logopts else set()
         unknown_params = []
         for key in params:
             if key in recipe.inputs_outputs:
                 continue
+            if key in assign_keys:
+                continue
             if "." in key:
-                prefix = key.split(".", 1)[0]
-                if prefix in recipe.steps or prefix in ("config", "log"):
+                prefix, subkey = key.split(".", 1)
+                if prefix == "config":
                     continue
+                if prefix == "log" and subkey.split(".", 1)[0] in log_fields:
+                    continue
+                if prefix in recipe.steps:
+                    step = recipe.steps[prefix]
+                    if subkey in step.inputs_outputs:
+                        continue
+                    if hasattr(step.cargo, "assign") and step.cargo.assign:
+                        step_assign_keys = _flatten_assign_keys(step.cargo.assign)
+                        if subkey in step_assign_keys:
+                            continue
             unknown_params.append(key)
         if unknown_params:
             log_exception(
@@ -611,6 +625,13 @@ def run(
                 )
             )
             sys.exit(1)
+
+        for key, value in params.items():
+            try:
+                recipe.assign_value(key, value, override=True)
+            except ScabhaBaseException as exc:
+                log_exception(exc)
+                sys.exit(1)
 
         # split out parameters
         params = {key: value for key, value in params.items() if key in recipe.inputs_outputs}

--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -593,6 +593,25 @@ def run(
 
         # create subst namespace for outer step
 
+        # check for unknown parameters: params that are not inputs/outputs and not
+        # valid nested assignments (step.param, config.xxx, log.xxx)
+        unknown_params = []
+        for key in params:
+            if key in recipe.inputs_outputs:
+                continue
+            if "." in key:
+                prefix = key.split(".", 1)[0]
+                if prefix in recipe.steps or prefix in ("config", "log"):
+                    continue
+            unknown_params.append(key)
+        if unknown_params:
+            log_exception(
+                RecipeValidationError(
+                    f"recipe '{recipe_name}': unknown parameter(s): {', '.join(repr(k) for k in unknown_params)}"
+                )
+            )
+            sys.exit(1)
+
         # split out parameters
         params = {key: value for key, value in params.items() if key in recipe.inputs_outputs}
 

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -153,11 +153,20 @@ def test_unknown_parameter():
     """Test that unknown parameters are rejected (issue #530)"""
     print("===== expecting an error for unknown parameter 'nonexistent' =====")
     retcode, output = run("stimela -v -b native exec test_aliasing.yml a=1 nonexistent=bar")
-    assert retcode != 0
+    assert retcode == 1
     assert verify_output(output, "unknown parameter")
 
-    print("===== valid parameters should still work =====")
+    print("===== expecting an error for unknown step parameter 's3.nonexistent' =====")
+    retcode, output = run("stimela -v -b native exec test_aliasing.yml a=1 s3.nonexistent=bar")
+    assert retcode == 1
+    assert verify_output(output, "unknown parameter")
+
+    print("===== valid step parameters should work =====")
     retcode, output = run("stimela -v -b native exec test_aliasing.yml a=1 s3.a=1 s4.a=1 e=e f=f")
+    assert retcode == 0
+
+    print("===== valid recipe assign key should work =====")
+    retcode, output = run("stimela -v -b native exec test_aliasing.yml a=1 s3.a=1 s4.a=1 e=e f=f nested.bar=yyy")
     assert retcode == 0
 
 

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -149,6 +149,18 @@ def test_issue527_3():
     assert verify_output(output, "invalid inputs")
 
 
+def test_unknown_parameter():
+    """Test that unknown parameters are rejected (issue #530)"""
+    print("===== expecting an error for unknown parameter 'nonexistent' =====")
+    retcode, output = run("stimela -v -b native exec test_aliasing.yml a=1 nonexistent=bar")
+    assert retcode != 0
+    assert verify_output(output, "unknown parameter")
+
+    print("===== valid parameters should still work =====")
+    retcode, output = run("stimela -v -b native exec test_aliasing.yml a=1 s3.a=1 s4.a=1 e=e f=f")
+    assert retcode == 0
+
+
 def test_scatter():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml basic_loop")


### PR DESCRIPTION
## Summary
- When a user specifies a parameter name that doesn't exist in the recipe schema (e.g. `stimela run recipe.yml foo=bar`), stimela now raises a clear error instead of silently ignoring it
- Validates CLI parameters against known inputs/outputs, step prefixes, config, and log targets before proceeding
- Adds test covering both the rejection of unknown params and acceptance of valid ones

Closes #530

## Test plan
- [x] `test_unknown_parameter` verifies unknown params are rejected with "unknown parameter" in output
- [x] `test_unknown_parameter` verifies valid params (including step-prefixed like `s3.a=1`) still work
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)