### PR TITLE
Fix maximum recursion depth exceeded for nested formulas

### DIFF
--- a/stimela/__init__.py
+++ b/stimela/__init__.py
@@ -6,7 +6,10 @@ from pathlib import Path
 # exceed Python's default limit of 1000. See https://github.com/caracal-pipeline/stimela/issues/462
 _MIN_RECURSION_LIMIT = 10000
 if sys.getrecursionlimit() < _MIN_RECURSION_LIMIT:
-    sys.setrecursionlimit(_MIN_RECURSION_LIMIT)
+    try:
+        sys.setrecursionlimit(_MIN_RECURSION_LIMIT)
+    except ValueError:
+        pass
 
 # -----------
 # knicked from https://github.com/python-poetry/poetry/issues/273#issuecomment-1103812336

--- a/stimela/__init__.py
+++ b/stimela/__init__.py
@@ -1,5 +1,12 @@
 import os
+import sys
 from pathlib import Path
+
+# pyparsing's infix_notation uses deep recursion; nested formulas (e.g. 4+ nested IFs)
+# exceed Python's default limit of 1000. See https://github.com/caracal-pipeline/stimela/issues/462
+_MIN_RECURSION_LIMIT = 10000
+if sys.getrecursionlimit() < _MIN_RECURSION_LIMIT:
+    sys.setrecursionlimit(_MIN_RECURSION_LIMIT)
 
 # -----------
 # knicked from https://github.com/python-poetry/poetry/issues/273#issuecomment-1103812336

--- a/tests/test_deeply_nested_formula.py
+++ b/tests/test_deeply_nested_formula.py
@@ -1,0 +1,18 @@
+import sys
+
+from .test_recipe import change_test_dir as change_test_dir
+from .test_recipe import run, verify_output
+
+
+def test_recursion_limit_is_raised():
+    """Verify stimela raises the recursion limit above the default (issue #462)."""
+    import stimela  # noqa: F401 — import for side-effect
+
+    assert sys.getrecursionlimit() >= 10000
+
+
+def test_deeply_nested_formula():
+    """A recipe with 4-level nested IFs in a skip condition must not crash (issue #462)."""
+    retcode, output = run("stimela -v -b native run test_deeply_nested_formula.yml")
+    assert retcode == 0
+    assert verify_output(output, "deeply nested skip evaluated successfully")

--- a/tests/test_deeply_nested_formula.yml
+++ b/tests/test_deeply_nested_formula.yml
@@ -1,0 +1,33 @@
+cabs:
+  echo:
+    command: echo
+    inputs:
+      msg:
+        dtype: str
+        required: true
+        policies:
+          positional: true
+
+recipe:
+  steps:
+    echo-1:
+      cab: echo
+      params:
+        msg: "deeply nested skip evaluated successfully"
+      skip: =IF(
+          true,
+          false,
+          IF(
+            true,
+            true,
+            IF(
+              true,
+              IF(
+                true,
+                true,
+                false
+              ),
+              false
+            )
+          )
+        )


### PR DESCRIPTION
## Summary
- Increases Python's recursion limit from the default 1000 to 10000 when stimela is imported
- pyparsing's `infix_notation` uses deep recursion for operator-precedence parsing, causing `RecursionError` with 4+ nested `IF()` calls in formulas
- The limit is only raised if it's currently below 10000 (won't lower a user-set higher limit)

Fixes #462

## Test plan
- [x] Added `test_recursion_limit_is_raised` — verifies the limit is >= 10000 after importing stimela
- [x] Added `test_deeply_nested_formula` — runs a recipe with 4-level nested `IF()` in a skip condition
- [x] Existing tests pass (pre-existing `test_test_recipe` failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)