### PR TITLE
Allow '+' and '@' characters in log file paths

### DIFF
--- a/stimela/stimelogging.py
+++ b/stimela/stimelogging.py
@@ -167,6 +167,11 @@ _boring = False
 
 LOG_DIR = "."
 
+# Characters allowed in log file paths: alphanumeric, dot, underscore, slash, at-sign, plus, hyphen.
+# The '+' and '@' characters are explicitly allowed so that e.g. J2000 coordinate names
+# (like J1939+4540) are preserved in log directory/file names (see issue #513).
+_RE_LOG_SANITIZE = re.compile(r"[^a-zA-Z0-9_./@+-]")
+
 
 def is_logger_initialized():
     return _logger is not None
@@ -357,7 +362,7 @@ def update_file_logger(
         # Expand path before removing non-filename characters.
         path = os.path.expanduser(path)
         # substitute non-filename characters for _
-        path = re.sub(r"[^a-zA-Z0-9_./-]", "_", path)
+        path = _RE_LOG_SANITIZE.sub("_", path)
 
         # setup the logger
         setup_file_logger(log, path, level=logopts.level, symlink=logopts.symlink)

--- a/tests/test_log_sanitization.py
+++ b/tests/test_log_sanitization.py
@@ -1,0 +1,50 @@
+"""Tests for log path sanitization in stimelogging.py (issue #513)."""
+
+from stimela.stimelogging import _RE_LOG_SANITIZE
+
+
+def sanitize_path(path: str) -> str:
+    """Replicate the log path sanitization logic from stimelogging.update_file_logger."""
+    return _RE_LOG_SANITIZE.sub("_", path)
+
+
+def test_plus_preserved_in_log_path():
+    """The '+' character in J2000 coordinate names should not be replaced (issue #513)."""
+    path = "logs/log-J1939+4540.txt"
+    assert sanitize_path(path) == "logs/log-J1939+4540.txt"
+
+
+def test_at_sign_preserved_in_log_path():
+    """The '@' character should be preserved in log paths."""
+    path = "logs/log-target@field.txt"
+    assert sanitize_path(path) == "logs/log-target@field.txt"
+
+
+def test_basic_alphanumeric_preserved():
+    """Standard alphanumeric characters, dots, underscores, hyphens, and slashes are preserved."""
+    path = "logs-20240101/log-my_recipe.step1.txt"
+    assert sanitize_path(path) == "logs-20240101/log-my_recipe.step1.txt"
+
+
+def test_special_chars_replaced():
+    """Characters outside the allowed set are still replaced with underscore."""
+    path = "logs/log-name with spaces.txt"
+    assert sanitize_path(path) == "logs/log-name_with_spaces.txt"
+
+
+def test_shell_metacharacters_replaced():
+    """Shell metacharacters like $, !, &, etc. are replaced."""
+    path = "logs/log-$var!.txt"
+    assert sanitize_path(path) == "logs/log-_var_.txt"
+
+
+def test_j2000_coordinate_full():
+    """A realistic J2000 coordinate target name is preserved correctly."""
+    path = "./logs-2024/log-recipe.J0521+1638.calibrate.txt"
+    assert sanitize_path(path) == "./logs-2024/log-recipe.J0521+1638.calibrate.txt"
+
+
+def test_negative_declination_preserved():
+    """J2000 coordinates with negative declination (using '-') are preserved."""
+    path = "logs/log-J1939-4540.txt"
+    assert sanitize_path(path) == "logs/log-J1939-4540.txt"


### PR DESCRIPTION
## Summary
- Fixes the log path sanitization regex in `stimela/stimelogging.py` to preserve `+` and `@` characters, so J2000 coordinate names (e.g. `J1939+4540`) are no longer silently altered in log directory/file names
- Extracts the sanitization regex into a module-level compiled constant `_RE_LOG_SANITIZE` for clarity and testability
- Adds 7 targeted tests in `tests/test_log_sanitization.py` covering preserved characters, replaced characters, and realistic J2000 coordinate patterns

Fixes #513

## Test plan
- [x] New tests in `tests/test_log_sanitization.py` pass (7/7)
- [x] Ruff lint and format checks pass
- [ ] Existing test suite passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)