### PR TITLE
Fix non-required outputs raising invalid parameter error

### DIFF
--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -592,11 +592,11 @@ class Step:
                         subst._add_("root", subst.current)
 
             ## check for (a) invalid params (b) unresolved inputs
-            # (c) unresolved outputs of File/MS/Directory type
+            # (c) unresolved required outputs of File/MS/Directory type
             invalid = self.invalid_params
             for name in self.unresolved_params:
                 schema = self.cargo.inputs_outputs[name]
-                if schema.is_input or schema.is_named_output:
+                if schema.is_input or (schema.is_named_output and schema.required):
                     invalid.append(name)
             if invalid:
                 if skip:

--- a/tests/test_issue324.yml
+++ b/tests/test_issue324.yml
@@ -1,0 +1,42 @@
+cabs:
+  echo:
+    command: echo
+    inputs:
+      msg:
+        dtype: str
+        default: "hello"
+    outputs:
+      temp-dir:
+        dtype: Directory
+        skip_freshness_checks: true
+        mkdir: true
+        must_exist: false
+        required: false
+
+  echo_required:
+    command: echo
+    inputs:
+      msg:
+        dtype: str
+        default: "hello"
+    outputs:
+      temp-dir:
+        dtype: Directory
+        skip_freshness_checks: true
+        mkdir: true
+        must_exist: false
+        required: true
+
+test_nonrequired_output:
+  steps:
+    s1:
+      cab: echo
+      params:
+        msg: "test message"
+
+test_required_output:
+  steps:
+    s1:
+      cab: echo_required
+      params:
+        msg: "test message"

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -149,6 +149,22 @@ def test_issue527_3():
     assert verify_output(output, "invalid inputs")
 
 
+def test_issue324_nonrequired_output():
+    """Test that non-required Directory outputs don't cause errors when unresolved (issue #324)"""
+    print("===== expecting no errors for non-required output =====")
+    retcode, output = run("stimela -v -b native run test_issue324.yml test_nonrequired_output")
+    print(output)
+    assert retcode == 0, f"Non-required output should not cause an error, but got retcode={retcode}"
+
+
+def test_issue324_required_output():
+    """Test that required Directory outputs still cause errors when unresolved (issue #324)"""
+    print("===== expecting an error for required output =====")
+    retcode, output = run("stimela -v -b native run test_issue324.yml test_required_output")
+    print(output)
+    assert retcode != 0, "Required output should cause an error when unresolved"
+
+
 def test_scatter():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml basic_loop")


### PR DESCRIPTION
## Summary
- Fixes #324: non-required Directory/File/MS outputs no longer raise "invalid inputs" errors when their values are Unresolved
- Changed the condition in `stimela/kitchen/step.py` line 599 to only flag unresolved named outputs as invalid when `schema.required` is truthy
- This aligns the pre-run validation with the existing post-run validation logic (line 797) which already checks `required is not False`

## Test plan
- [x] Added `test_issue324_nonrequired_output` -- verifies a cab with `required: false` Directory output runs without error
- [x] Added `test_issue324_required_output` -- verifies a cab with `required: true` Directory output still raises an error when unresolved
- [x] All existing tests pass (except `test_test_recipe` which is a pre-existing failure on master)
- [x] Ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)