### PR TITLE
Switch from Singularity to Apptainer

### DIFF
--- a/stimela/backends/__init__.py
+++ b/stimela/backends/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional
@@ -17,9 +18,17 @@ from .slurm import SlurmOptions
 
 ## left as memo to self
 # Backend = Enum("Backend", "docker singularity podman kubernetes native", module=__name__)
-Backend = Enum("Backend", "singularity kube native", module=__name__)
+Backend = Enum("Backend", "apptainer singularity kube native", module=__name__)
 
 SUPPORTED_BACKENDS = set(Backend.__members__)
+
+# 'apptainer' is the canonical name; 'singularity' is a deprecated alias that maps to the same module
+_BACKEND_ALIASES = {"apptainer": "singularity"}
+
+
+def _resolve_backend_module_name(name: str) -> str:
+    """Resolves a backend name to its actual module name, following aliases."""
+    return _BACKEND_ALIASES.get(name, name)
 
 
 def get_backend(name: str, backend_opts: Optional[Dict] = None):
@@ -29,7 +38,8 @@ def get_backend(name: str, backend_opts: Optional[Dict] = None):
     """
     if name not in SUPPORTED_BACKENDS:
         return None
-    backend = __import__(f"stimela.backends.{name}", fromlist=[name])
+    module_name = _resolve_backend_module_name(name)
+    backend = __import__(f"stimela.backends.{module_name}", fromlist=[module_name])
     if backend.is_available(backend_opts):
         return backend
     return None
@@ -38,7 +48,8 @@ def get_backend(name: str, backend_opts: Optional[Dict] = None):
 def get_backend_status(name: str):
     if name not in SUPPORTED_BACKENDS:
         return "unknown backend"
-    backend = __import__(f"stimela.backends.{name}", fromlist=[name])
+    module_name = _resolve_backend_module_name(name)
+    backend = __import__(f"stimela.backends.{module_name}", fromlist=[module_name])
     return backend.get_status()
 
 
@@ -50,12 +61,13 @@ class StimelaBackendOptions(object):
     override_registries: Dict[str, str] = EmptyDictDefault()
 
     # should be Union[str, List[str]], but OmegaConf doesn't support it, so handle in __post_init__ for now
-    select: Any = "singularity,native"
+    select: Any = "apptainer,native"
 
     # selects a backend variety
     variety: Optional[str] = None
 
-    singularity: Optional[SingularityBackendOptions] = EmptyClassDefault(SingularityBackendOptions)
+    apptainer: Optional[SingularityBackendOptions] = EmptyClassDefault(SingularityBackendOptions)
+    singularity: Optional[SingularityBackendOptions] = None  # deprecated alias for apptainer, synced in __post_init__
     kube: Optional[KubeBackendOptions] = EmptyClassDefault(KubeBackendOptions)
     native: Optional[NativeBackendOptions] = EmptyClassDefault(NativeBackendOptions)
     docker: Optional[Dict] = None  # placeholder for future impl
@@ -77,9 +89,22 @@ class StimelaBackendOptions(object):
             self.select = list(self.select)
         else:
             raise BackendSpecificationError(f"invalid backend.select setting of type {self.select}")
-        # provide default options for available backends
-        if self.singularity is None and get_backend("singularity"):
-            self.singularity = SingularityBackendOptions()
+        # emit deprecation warning if 'singularity' is explicitly selected
+        if "singularity" in self.select:
+            warnings.warn(
+                "The 'singularity' backend name is deprecated and will be removed in a future release. "
+                "Please use 'apptainer' instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        # sync apptainer/singularity options: if user set singularity explicitly, prefer it
+        if self.singularity is not None:
+            self.apptainer = self.singularity
+        # provide default options for apptainer if needed
+        if self.apptainer is None and get_backend("apptainer"):
+            self.apptainer = SingularityBackendOptions()
+        # singularity always points to apptainer (deprecated alias)
+        self.singularity = self.apptainer
         if self.native is None and get_backend("native"):
             self.native = NativeBackendOptions()
         if self.kube is None and get_backend("kube"):

--- a/stimela/backends/runner.py
+++ b/stimela/backends/runner.py
@@ -60,7 +60,7 @@ def validate_backend_settings(
     if not isinstance(backend_opts, StimelaBackendOptions):
         backend_opts = OmegaConf.to_object(backend_opts)
 
-    selected = backend_opts.select or ["singularity", "native"]
+    selected = backend_opts.select or ["apptainer", "native"]
     # select backend engine
 
     excuses = {}

--- a/stimela/backends/singularity.py
+++ b/stimela/backends/singularity.py
@@ -91,7 +91,7 @@ def is_available(opts: Optional[SingularityBackendOptions] = None):
         if opts and opts.remote_only:
             STATUS = VERSION = "remote"
         else:
-            BINARY = (opts and opts.executable) or which("singularity")
+            BINARY = (opts and opts.executable) or which("apptainer") or which("singularity")
             if BINARY:
                 __version_string = subprocess.check_output([BINARY, "--version"]).decode("utf8")
                 STATUS = VERSION = __version_string.strip().split()[-1]

--- a/stimela/commands/build.py
+++ b/stimela/commands/build.py
@@ -8,7 +8,7 @@ from .run import run
 @click.command(
     "build",
     help="""
-    Builds singularity images required by the recipe. Only available if the singularity backend is selected.
+    Builds container images required by the recipe. Available if the apptainer backend is selected.
     """,
     no_args_is_help=True,
 )
@@ -79,11 +79,18 @@ from .run import run
     "-l", "--last-recipe", is_flag=True, help="""if multiple recipes are defined, selects the last one for building."""
 )
 @click.option(
+    "-A",
+    "--apptainer",
+    "enable_apptainer",
+    is_flag=True,
+    help="""Selects the apptainer backend (shortcut for -C opts.backend.select=apptainer)""",
+)
+@click.option(
     "-S",
     "--singularity",
     "enable_singularity",
     is_flag=True,
-    help="""Selects the singularity backend (shortcut for -C opts.backend.select=singularity)""",
+    help="""[Deprecated: use --apptainer] Selects the apptainer/singularity backend""",
 )
 @click.option(
     "--slurm",
@@ -111,6 +118,7 @@ def build(
     tags: List[str] = [],
     skip_tags: List[str] = [],
     enable_steps: List[str] = [],
+    enable_apptainer=False,
     enable_singularity=False,
     enable_slurm=False,
     parameter_file: List[str] = [],
@@ -127,6 +135,7 @@ def build(
         build=True,
         rebuild=rebuild,
         build_skips=all_steps,
+        enable_apptainer=enable_apptainer,
         enable_singularity=enable_singularity,
         enable_slurm=enable_slurm,
         parameter_file=parameter_file,

--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -307,11 +307,18 @@ def load_recipe_files(filenames: List[str]):
     help="""Selects the native backend (shortcut for -C opts.backend.select=native)""",
 )
 @click.option(
+    "-A",
+    "--apptainer",
+    "enable_apptainer",
+    is_flag=True,
+    help="""Selects the apptainer backend (shortcut for -C opts.backend.select=apptainer)""",
+)
+@click.option(
     "-S",
     "--singularity",
     "enable_singularity",
     is_flag=True,
-    help="""Selects the singularity backend (shortcut for -C opts.backend.select=singularity)""",
+    help="""[Deprecated: use --apptainer] Selects the apptainer/singularity backend""",
 )
 @click.option(
     "-K",
@@ -360,6 +367,7 @@ def run(
     rebuild=False,
     build_skips=False,
     enable_native=False,
+    enable_apptainer=False,
     enable_singularity=False,
     enable_kube=False,
     enable_slurm=False,
@@ -458,9 +466,19 @@ def run(
     if enable_native:
         log.info("selecting the native backend")
         stimela.CONFIG.opts.backend.select = "native"
+    elif enable_apptainer:
+        log.info("selecting the apptainer backend")
+        stimela.CONFIG.opts.backend.select = "apptainer"
     elif enable_singularity:
-        log.info("selecting the singularity backend")
-        stimela.CONFIG.opts.backend.select = "singularity"
+        import warnings
+
+        warnings.warn(
+            "The --singularity/-S flag is deprecated. Please use --apptainer/-A instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        log.info("selecting the apptainer backend (via deprecated --singularity flag)")
+        stimela.CONFIG.opts.backend.select = "apptainer"
     elif enable_kube:
         log.info("selecting the kube backend")
         stimela.CONFIG.opts.backend.select = "kube"

--- a/stimela/display/display.py
+++ b/stimela/display/display.py
@@ -53,6 +53,8 @@ class Display:
     style_map = {
         ("native", "simple"): SimpleLocalDisplay,
         ("native", "fancy"): LocalDisplay,
+        ("apptainer", "simple"): SimpleLocalDisplay,
+        ("apptainer", "fancy"): LocalDisplay,
         ("singularity", "simple"): SimpleLocalDisplay,
         ("singularity", "fancy"): LocalDisplay,
         ("kube", "simple"): SimpleKubeDisplay,

--- a/stimela/monitoring/__init__.py
+++ b/stimela/monitoring/__init__.py
@@ -17,6 +17,7 @@ def dummy_reporter(now, task_info):
 
 REPORTERS = {
     "native": local_reporter,
+    "apptainer": local_reporter,
     "singularity": local_reporter,
     "slurm": slurm_reporter,
     "kube": local_reporter,  # For now - this needs testing. Slurm may be more appropriate.

--- a/tests/test_apptainer_backend.py
+++ b/tests/test_apptainer_backend.py
@@ -1,0 +1,97 @@
+"""Tests for the apptainer backend alias and singularity deprecation."""
+
+import warnings
+
+from stimela.backends import (
+    SUPPORTED_BACKENDS,
+    StimelaBackendOptions,
+    get_backend_status,
+)
+from stimela.backends.singularity import SingularityBackendOptions
+
+
+def test_apptainer_in_supported_backends():
+    """Apptainer should be listed as a supported backend."""
+    assert "apptainer" in SUPPORTED_BACKENDS
+
+
+def test_singularity_still_in_supported_backends():
+    """Singularity should still be a supported backend for backward compatibility."""
+    assert "singularity" in SUPPORTED_BACKENDS
+
+
+def test_default_select_prefers_apptainer():
+    """Default backend selection should prefer apptainer over singularity."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        opts = StimelaBackendOptions()
+    assert opts.select[0] == "apptainer"
+    assert "native" in opts.select
+
+
+def test_singularity_select_emits_deprecation_warning():
+    """Selecting 'singularity' backend should emit a FutureWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        StimelaBackendOptions(select="singularity")  # noqa: F841
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) >= 1
+        assert "deprecated" in str(future_warnings[0].message).lower()
+        assert "apptainer" in str(future_warnings[0].message).lower()
+
+
+def test_apptainer_select_no_warning():
+    """Selecting 'apptainer' backend should not emit a deprecation warning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        StimelaBackendOptions(select="apptainer")  # noqa: F841
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 0
+
+
+def test_apptainer_and_singularity_options_synced():
+    """The apptainer and singularity options should point to the same object."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        opts = StimelaBackendOptions()
+    # They should be the same object (or at least equivalent)
+    assert opts.apptainer is not None
+    assert opts.singularity is not None
+    assert opts.apptainer is opts.singularity
+
+
+def test_apptainer_backend_resolves_to_singularity_module():
+    """The 'apptainer' backend should resolve to the singularity backend module."""
+    from stimela.backends import _resolve_backend_module_name
+
+    assert _resolve_backend_module_name("apptainer") == "singularity"
+    assert _resolve_backend_module_name("singularity") == "singularity"
+    assert _resolve_backend_module_name("native") == "native"
+    assert _resolve_backend_module_name("kube") == "kube"
+
+
+def test_get_backend_status_apptainer():
+    """get_backend_status('apptainer') should return a valid status string."""
+    status = get_backend_status("apptainer")
+    # Should be either a version string or "not installed", not "unknown backend"
+    assert status != "unknown backend"
+
+
+def test_singularity_options_backward_compat():
+    """Setting singularity options should also affect apptainer options."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        sing_opts = SingularityBackendOptions(auto_build=False)
+        opts = StimelaBackendOptions(singularity=sing_opts)
+    assert opts.apptainer.auto_build is False
+    assert opts.singularity.auto_build is False
+
+
+def test_apptainer_options_set_singularity():
+    """Setting apptainer options should also set singularity options."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        app_opts = SingularityBackendOptions(contain=False)
+        opts = StimelaBackendOptions(apptainer=app_opts)
+    assert opts.apptainer.contain is False
+    assert opts.singularity.contain is False


### PR DESCRIPTION
## Summary
- Add `apptainer` as the canonical backend name, with `singularity` retained as a deprecated alias that maps to the same module
- In `singularity.py`, binary detection now prefers `apptainer` over `singularity` (`which("apptainer") or which("singularity")`)
- Emit `FutureWarning` when `singularity` is explicitly selected as a backend (via config or CLI flags)
- Default backend selection changed from `singularity,native` to `apptainer,native`
- Add `--apptainer`/`-A` CLI flags to `run` and `build` commands; `--singularity`/`-S` flags still work but show deprecation warning
- Add `apptainer` entries to display style map and monitoring reporters
- 10 new tests covering backend alias resolution, deprecation warnings, and options synchronization

Closes #548

## Test plan
- [x] All 10 new `test_apptainer_backend.py` tests pass
- [x] All 9 existing `test_backend_validation_singularity_native.py` tests pass (backward compat)
- [x] `test_backend_varieties` passes
- [x] Ruff lint and format checks pass
- [ ] Verify on a system with `apptainer` binary installed
- [ ] Verify on a system with only `singularity` binary installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)