### PR TITLE
Fix {}-substitution for List[Tuple[float,float]] types

### DIFF
--- a/stimela/__init__.py
+++ b/stimela/__init__.py
@@ -29,3 +29,9 @@ Path(LOG_HOME).mkdir(exist_ok=True)
 LOG_FILE = "{0:s}/stimela_logfile.json".format(LOG_HOME)
 
 from .stimelogging import logger, log_exception  # noqa
+
+# Apply scabha patches for complex type coercion (issue #364)
+from ._patches import apply_patches as _apply_patches  # noqa: E402
+
+_apply_patches()
+del _apply_patches

--- a/stimela/_patches.py
+++ b/stimela/_patches.py
@@ -1,0 +1,343 @@
+"""Patches for scabha to fix known issues until they are upstreamed.
+
+This module monkey-patches scabha.validate.validate_parameters to add
+string-to-complex-type coercion. When a parameter value arrives as a string
+(e.g. from {}-substitution which stringifies list/tuple values) but the
+expected dtype is a composite type (List, Tuple, Dict, etc.), the original
+validate_parameters fails with a pydantic validation error.
+
+The fix attempts to parse string values via ast.literal_eval or
+yaml.safe_load before passing them to pydantic, recovering the intended
+Python object.
+
+See: https://github.com/caracal-pipeline/stimela/issues/364
+"""
+
+import ast
+import logging
+from typing import get_origin
+
+import scabha.validate as _scabha_validate
+import yaml
+
+log = logging.getLogger(__name__)
+
+
+def _coerce_string_to_complex_type(value, dtype):
+    """Try to coerce a string value into the expected complex type.
+
+    When a value passes through {}-substitution, Python's string formatter
+    converts it to its str() representation. For composite types like
+    List[Tuple[float, float]], this produces a string like
+    '[(1.0, 2.0), (3.0, 4.0)]' which pydantic cannot validate directly.
+
+    This function attempts to recover the original Python object by first
+    trying ast.literal_eval (which correctly handles Python literal syntax
+    including tuples), then falling back to yaml.safe_load (which handles
+    YAML-style list/dict literals). ast.literal_eval is preferred because
+    str() on a Python object produces valid Python literal syntax, while
+    YAML incorrectly parses parenthesized tuples as strings.
+
+    Returns the parsed value on success, or the original string on failure.
+    """
+    if not isinstance(value, str):
+        return value
+
+    # Only attempt coercion for composite types (List, Tuple, Dict, Set, etc.)
+    origin = get_origin(dtype)
+    if origin is None:
+        # Not a generic type; skip coercion for simple types like str, int, float
+        return value
+
+    # Don't attempt to parse file-type parameters -- those have their own
+    # handling logic later in validate_parameters.
+    from scabha.basetypes import is_file_list_type, is_file_type
+
+    if is_file_type(dtype) or is_file_list_type(dtype):
+        return value
+
+    # First try ast.literal_eval -- correctly handles Python literal syntax
+    # including tuples. This is the preferred parser because {}-substitution
+    # produces str() output which is valid Python syntax.
+    try:
+        parsed = ast.literal_eval(value)
+        if parsed is not None and not isinstance(parsed, str):
+            return parsed
+    except Exception:
+        pass
+
+    # Fall back to yaml.safe_load for YAML-style list/dict literals
+    try:
+        parsed = yaml.safe_load(value)
+        if parsed is not None and not isinstance(parsed, str):
+            return parsed
+    except Exception:
+        pass
+
+    return value
+
+
+def _make_patched_validate_parameters():
+    """Build and return the patched validate_parameters function.
+
+    We capture the original function at patch-time to avoid import loops.
+    The patch inserts string-to-complex-type coercion into the type-coercion
+    section of validate_parameters -- after {}-substitution has already run,
+    but before pydantic validation. This is the correct insertion point
+    because:
+
+    1. {}-substitution stringifies complex values (e.g. list -> "[(1,2)]")
+    2. The existing coercion only handles OmegaConf containers and bool->str
+    3. We need to parse those strings back into Python objects for pydantic
+
+    Rather than duplicating the entire function, we use a thin wrapper that
+    patches the inputs dict after calling the original substitution logic
+    but before the pydantic validation step. We do this by intercepting the
+    inputs after substitution.
+    """
+    import dataclasses
+    import keyword
+    import os
+    import os.path
+    import pathlib
+    import re
+    from collections import OrderedDict
+    from typing import Any, Dict, List, Optional
+
+    import pydantic
+    import pydantic.dataclasses
+    from omegaconf import DictConfig, ListConfig, OmegaConf
+    from scabha.basetypes import MS, UNSET, URI, Directory, File, Unresolved
+    from scabha.exceptions import Error, ParameterValidationError
+    from scabha.validate import (
+        _VALIDATION_CONFIG,
+        evaluate_and_substitute,
+        join_quote,
+    )
+
+    def patched_validate_parameters(
+        params: Dict[str, Any],
+        schemas: Dict[str, Any],
+        defaults: Optional[Dict[str, Any]] = None,
+        subst=None,
+        fqname: str = "",
+        check_unknowns=True,
+        check_required=True,
+        check_inputs_exist=True,
+        check_outputs_exist=True,
+        create_dirs=False,
+        ignore_subst_errors=False,
+        log: Optional[logging.Logger] = None,
+    ) -> Dict[str, Any]:
+        """Patched validate_parameters with string-to-complex-type coercion.
+
+        This is a copy of scabha.validate.validate_parameters with an additional
+        coercion step: after {}-substitution, string values whose target dtype is
+        a composite type (List, Tuple, Dict, etc.) are parsed via ast.literal_eval
+        or yaml.safe_load to recover the original Python object.
+        """
+        if fqname:
+            mkname = lambda name: f"{fqname}.{name}"  # noqa: E731
+        else:
+            mkname = lambda name: name  # noqa: E731
+
+        if check_unknowns:
+            for name in params:
+                if name not in schemas:
+                    raise ParameterValidationError(f"unknown parameter '{mkname(name)}'")
+
+        inputs = OrderedDict((name, value) for name, value in params.items() if name in schemas)
+
+        all_defaults = {
+            name: schema.default
+            for name, schema in schemas.items()
+            if schema.default is not UNSET and schema.default != "UNSET"
+        }
+        if defaults:
+            all_defaults.update(**{name: value for name, value in defaults.items() if name in schemas})
+
+        inputs.update(**{name: value for name, value in all_defaults.items() if name not in inputs})
+
+        if subst is not None:
+            inputs = evaluate_and_substitute(
+                inputs,
+                subst,
+                subst.current,
+                defaults=all_defaults,
+                ignore_subst_errors=ignore_subst_errors,
+                location=[fqname],
+                log=log,
+            )
+
+        unresolved = {name: value for name, value in inputs.items() if isinstance(value, Unresolved)}
+        inputs = {name: value for name, value in inputs.items() if not isinstance(value, Unresolved)}
+
+        if check_required:
+            missing = [
+                mkname(name)
+                for name, schema in schemas.items()
+                if schema.required and inputs.get(name) is UNSET and name not in unresolved
+            ]
+            if missing:
+                raise ParameterValidationError(f"missing required parameters: {join_quote(missing)}")
+
+        validated = {}
+        fields = []
+        name2field = {}
+        field2name = {}
+
+        for name, schema in schemas.items():
+            value = inputs.get(name, UNSET)
+            if value is not UNSET:
+                fldname = orig_fldname = re.sub("\\W", "_", name)
+                num = 0
+                while (
+                    keyword.iskeyword(fldname)
+                    or (hasattr(keyword, "issoftkeyword") and keyword.issoftkeyword(fldname))
+                    or fldname in field2name
+                ):
+                    fldname += f"{orig_fldname}_{num}"
+                    num += 1
+                field2name[fldname] = name
+                name2field[name] = fldname
+
+                fields.append((fldname, schema._dtype))
+
+                # OmegaConf dicts/lists need to be converted to standard containers for pydantic to take them
+                if isinstance(value, (ListConfig, DictConfig)):
+                    inputs[name] = OmegaConf.to_container(value)
+                elif isinstance(value, bool) and schema._dtype is str:
+                    inputs[name] = str(value)
+                # === PATCH: coerce string values to complex types (issue #364) ===
+                elif isinstance(value, str) and not isinstance(value, Unresolved):
+                    coerced = _coerce_string_to_complex_type(value, schema._dtype)
+                    if coerced is not value:
+                        inputs[name] = coerced
+
+        dcls = dataclasses.make_dataclass("Parameters", fields)
+        pcls = pydantic.dataclasses.dataclass(dcls, config=_VALIDATION_CONFIG)
+
+        for name, value in list(inputs.items()):
+            schema = schemas.get(name)
+            if schema is None:
+                continue
+            if value is UNSET or isinstance(value, Error):
+                continue
+            dtype = schema._dtype
+
+            if schema.is_input:
+                must_exist = check_inputs_exist and schema.must_exist is not False
+            elif schema.is_output:
+                must_exist = check_outputs_exist and schema.must_exist
+
+            if schema.is_file_type or schema.is_file_list_type:
+                if isinstance(value, str):
+                    try:
+                        files = yaml.safe_load(value)
+                        if type(files) is not list:
+                            files = [value]
+                    except Exception:
+                        files = [value]
+                elif isinstance(value, (list, tuple)):
+                    files = value
+                else:
+                    raise ParameterValidationError(f"'{mkname(name)}={value}': invalid type '{type(value)}'")
+                files = [URI(f) for f in files]
+
+                if must_exist:
+                    if not files and not schema.is_file_list_type:
+                        raise ParameterValidationError(f"'{mkname(name)}': file doesn't exist")
+                    not_exists = [uri.path for uri in files if not uri.remote and not os.path.exists(uri.path)]
+                    if not_exists:
+                        raise ParameterValidationError(f"'{mkname(name)}': {','.join(not_exists)} doesn't exist")
+
+                if schema.is_file_type:
+                    if len(files) > 1:
+                        raise ParameterValidationError(f"'{mkname(name)}': multiple files given ({value})")
+                    elif not files:
+                        inputs[name] = ""
+                    else:
+                        uri = files[0]
+                        if not uri.remote and os.path.exists(uri.path):
+                            if dtype == File:
+                                if not os.path.isfile(uri.path):
+                                    raise ParameterValidationError(f"'{mkname(name)}': {uri} is not a regular file")
+                            elif dtype == Directory or dtype == MS:
+                                if not os.path.isdir(uri.path):
+                                    raise ParameterValidationError(f"'{mkname(name)}': {uri} is not a directory")
+                        inputs[name] = str(uri)
+                else:
+                    if dtype == List[File]:
+                        if not all(
+                            os.path.isfile(uri.path) for uri in files if not uri.remote and os.path.exists(uri.path)
+                        ):
+                            raise ParameterValidationError(f"{mkname(name)}: {value} contains non-files")
+                    elif dtype == List[Directory] or dtype == List[MS]:
+                        if not all(
+                            os.path.isdir(uri.path) for uri in files if not uri.remote and os.path.exists(uri.path)
+                        ):
+                            raise ParameterValidationError(f"{mkname(name)}: {value} contains non-directories")
+                    inputs[name] = list(map(str, files))
+
+        try:
+            validated = pcls(
+                **{name2field[name]: value for name, value in inputs.items() if name in schemas and value is not UNSET}
+            )
+        except pydantic.ValidationError as exc:
+            errors = []
+            for err in exc.errors():
+                loc = ".".join([field2name.get(x, str(x)) for x in err["loc"]])
+                if loc in inputs:
+                    errors.append(ParameterValidationError(f"{loc} = {inputs[loc]}: {err['msg']}"))
+                else:
+                    errors.append(ParameterValidationError(f"{loc}: {err['msg']}"))
+            raise ParameterValidationError(f"{len(errors)} parameter(s) failed validation:", errors)
+
+        validated = {field2name[fld]: value for fld, value in dataclasses.asdict(validated).items()}
+
+        for name, value in validated.items():
+            if value is None:
+                continue
+            schema = schemas[name]
+            if schema.choices and value not in schema.choices:
+                raise ParameterValidationError(f"{mkname(name)}: invalid value '{value}'")
+            if schema.element_choices:
+                listval = value if isinstance(value, (list, tuple, ListConfig)) else [value]
+                for elem in listval:
+                    if elem not in schema.element_choices:
+                        raise ParameterValidationError(f"{mkname(name)}: invalid list element '{elem}'")
+
+        if create_dirs:
+            for name, value in validated.items():
+                schema = schemas[name]
+                if schema.is_output and (schema.mkdir or schema.path_policies.mkdir_parent):
+                    if schema.is_file_type:
+                        files = [URI(value)]
+                    elif schema.is_file_list_type:
+                        files = map(URI, value)
+                    else:
+                        continue
+                    for uri in files:
+                        if not uri.remote:
+                            path = pathlib.Path(uri.path)
+                            if schema.mkdir and (schema._dtype == Directory or schema._dtype == List[Directory]):
+                                path.mkdir(parents=True, exist_ok=True)
+                            elif schema.path_policies.mkdir_parent:
+                                path.parent.mkdir(parents=True, exist_ok=True)
+
+        validated.update(**unresolved)
+
+        return validated
+
+    return patched_validate_parameters
+
+
+def apply_patches():
+    """Apply all scabha patches. Should be called once at stimela import time."""
+    patched = _make_patched_validate_parameters()
+    _scabha_validate.validate_parameters = patched
+    # Also patch the reference in scabha.cargo since it imports validate_parameters directly
+    import scabha.cargo as _scabha_cargo
+
+    _scabha_cargo.validate_parameters = patched
+    log.debug("Applied scabha validation patches for complex type coercion (issue #364)")

--- a/tests/test_complex_type_coercion.py
+++ b/tests/test_complex_type_coercion.py
@@ -1,0 +1,206 @@
+"""Tests for complex type coercion in {}-substitution (issue #364).
+
+When a parameter value passes through {}-substitution, Python's string
+formatter converts it to its str() representation. For composite types like
+List[Tuple[float, float]], this produces a string that pydantic cannot
+validate directly. The patch in stimela._patches fixes this by parsing
+string values back into Python objects before validation.
+"""
+
+import pytest
+import scabha.validate  # noqa: E402
+from scabha.cargo import Parameter  # noqa: E402
+from scabha.substitutions import SubstitutionNS  # noqa: E402
+
+# Import stimela to apply the scabha patches before importing scabha.validate
+import stimela  # noqa: F401 -- side-effect: applies scabha patches
+
+
+@pytest.fixture(autouse=True)
+def change_test_dir(request, monkeypatch):
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+def _make_schemas(**dtypes):
+    """Helper: build a schemas dict from name=dtype_string pairs."""
+    return {name: Parameter(dtype=dtype) for name, dtype in dtypes.items()}
+
+
+def _validate(params, schemas, **kwargs):
+    """Shortcut for validate_parameters with common defaults.
+
+    Uses scabha.validate.validate_parameters (accessed via module attribute)
+    so that the patched version is called rather than the original.
+    """
+    return scabha.validate.validate_parameters(
+        params,
+        schemas,
+        check_required=False,
+        check_inputs_exist=False,
+        check_outputs_exist=False,
+        **kwargs,
+    )
+
+
+# ---- List[Tuple[float, float]] - the original bug ----
+
+
+class TestListTupleCoercion:
+    """Tests for the core bug: List[Tuple[float, float]] via {}-substitution."""
+
+    def test_string_with_tuple_syntax(self):
+        """String produced by str() on a list of tuples should be parsed."""
+        schemas = _make_schemas(kernel="List[Tuple[float,float]]")
+        result = _validate({"kernel": "[(1.0, 2.0), (3.0, 4.0)]"}, schemas)
+        assert result["kernel"] == [(1.0, 2.0), (3.0, 4.0)]
+
+    def test_string_with_list_syntax(self):
+        """String produced by str() on a list of lists should be parsed."""
+        schemas = _make_schemas(kernel="List[Tuple[float,float]]")
+        result = _validate({"kernel": "[[1.0, 2.0], [3.0, 4.0]]"}, schemas)
+        assert result["kernel"] == [(1.0, 2.0), (3.0, 4.0)]
+
+    def test_direct_list_of_tuples(self):
+        """Direct list of tuples should still work (regression check)."""
+        schemas = _make_schemas(kernel="List[Tuple[float,float]]")
+        result = _validate({"kernel": [(1.0, 2.0), (3.0, 4.0)]}, schemas)
+        assert result["kernel"] == [(1.0, 2.0), (3.0, 4.0)]
+
+    def test_direct_list_of_lists(self):
+        """Direct list of lists should be coerced to tuples by pydantic."""
+        schemas = _make_schemas(kernel="List[Tuple[float,float]]")
+        result = _validate({"kernel": [[1.0, 2.0], [3.0, 4.0]]}, schemas)
+        assert result["kernel"] == [(1.0, 2.0), (3.0, 4.0)]
+
+    def test_formula_substitution(self):
+        """=recipe.kernel should resolve to the Python object directly."""
+        schemas = _make_schemas(kernel="List[Tuple[float,float]]")
+        current = SubstitutionNS(kernel="=recipe.kernel")
+        subst = SubstitutionNS(
+            recipe=SubstitutionNS(kernel=[[1.0, 2.0], [3.0, 4.0]]),
+            current=current,
+        )
+        result = _validate({"kernel": "=recipe.kernel"}, schemas, subst=subst)
+        assert result["kernel"] == [(1.0, 2.0), (3.0, 4.0)]
+
+    def test_brace_substitution(self):
+        """{recipe.kernel} should stringify then be parsed back correctly."""
+        schemas = _make_schemas(kernel="List[Tuple[float,float]]")
+        current = SubstitutionNS(kernel="{recipe.kernel}")
+        subst = SubstitutionNS(
+            recipe=SubstitutionNS(kernel=[[1.0, 2.0], [3.0, 4.0]]),
+            current=current,
+        )
+        result = _validate({"kernel": "{recipe.kernel}"}, schemas, subst=subst)
+        assert result["kernel"] == [(1.0, 2.0), (3.0, 4.0)]
+
+
+# ---- Other composite types ----
+
+
+class TestOtherCompositeTypes:
+    """Verify coercion works for other composite types too."""
+
+    def test_list_int_from_string(self):
+        schemas = _make_schemas(nums="List[int]")
+        result = _validate({"nums": "[1, 2, 3]"}, schemas)
+        assert result["nums"] == [1, 2, 3]
+
+    def test_tuple_float_from_string(self):
+        schemas = _make_schemas(point="Tuple[float, float]")
+        result = _validate({"point": "(1.0, 2.0)"}, schemas)
+        assert result["point"] == (1.0, 2.0)
+
+    def test_dict_str_int_from_string(self):
+        schemas = _make_schemas(mapping="Dict[str, int]")
+        result = _validate({"mapping": "{'a': 1, 'b': 2}"}, schemas)
+        assert result["mapping"] == {"a": 1, "b": 2}
+
+    def test_optional_list_float_from_string(self):
+        schemas = _make_schemas(vals="Optional[List[float]]")
+        result = _validate({"vals": "[1.0, 2.0, 3.0]"}, schemas)
+        assert result["vals"] == [1.0, 2.0, 3.0]
+
+    def test_list_list_int_from_string(self):
+        schemas = _make_schemas(matrix="List[List[int]]")
+        result = _validate({"matrix": "[[1, 2], [3, 4]]"}, schemas)
+        assert result["matrix"] == [[1, 2], [3, 4]]
+
+    def test_tuple_str_int_from_string(self):
+        schemas = _make_schemas(pair="Tuple[str, int]")
+        result = _validate({"pair": "('hello', 42)"}, schemas)
+        assert result["pair"] == ("hello", 42)
+
+
+# ---- Non-composite types should NOT be affected ----
+
+
+class TestSimpleTypesUnaffected:
+    """Ensure simple types are not broken by the coercion patch."""
+
+    def test_str_value_unchanged(self):
+        schemas = _make_schemas(name="str")
+        result = _validate({"name": "hello world"}, schemas)
+        assert result["name"] == "hello world"
+
+    def test_int_from_string(self):
+        """Pydantic's own coercion handles str->int."""
+        schemas = _make_schemas(count="int")
+        result = _validate({"count": "42"}, schemas)
+        assert result["count"] == 42
+
+    def test_float_from_string(self):
+        """Pydantic's own coercion handles str->float."""
+        schemas = _make_schemas(value="float")
+        result = _validate({"value": "3.14"}, schemas)
+        assert result["value"] == pytest.approx(3.14)
+
+    def test_bool_from_direct_value(self):
+        schemas = _make_schemas(flag="bool")
+        result = _validate({"flag": True}, schemas)
+        assert result["flag"] is True
+
+
+# ---- File types should NOT be affected ----
+
+
+class TestFileTypesUnaffected:
+    """Ensure file-type parameters are handled by original logic, not coerced."""
+
+    def test_file_type(self):
+        schemas = _make_schemas(fname="File")
+        result = _validate({"fname": "/tmp/test.txt"}, schemas)
+        assert "test.txt" in result["fname"]
+
+    def test_list_file_type(self):
+        schemas = _make_schemas(fnames="List[File]")
+        result = _validate({"fnames": "[/tmp/a.txt, /tmp/b.txt]"}, schemas)
+        assert len(result["fnames"]) == 2
+
+
+# ---- Edge cases ----
+
+
+class TestEdgeCases:
+    """Edge cases for the coercion logic."""
+
+    def test_empty_list_string(self):
+        schemas = _make_schemas(items="List[int]")
+        result = _validate({"items": "[]"}, schemas)
+        assert result["items"] == []
+
+    def test_single_element_list_string(self):
+        schemas = _make_schemas(items="List[int]")
+        result = _validate({"items": "[42]"}, schemas)
+        assert result["items"] == [42]
+
+    def test_nested_tuples_string(self):
+        schemas = _make_schemas(data="List[Tuple[int, int, int]]")
+        result = _validate({"data": "[(1, 2, 3), (4, 5, 6)]"}, schemas)
+        assert result["data"] == [(1, 2, 3), (4, 5, 6)]
+
+    def test_invalid_string_passes_through(self):
+        """A string that can't be parsed should be passed to pydantic as-is."""
+        schemas = _make_schemas(items="List[int]")
+        with pytest.raises(Exception):
+            _validate({"items": "not a list at all"}, schemas)


### PR DESCRIPTION
## Summary

- Fixes {}-substitution failure on complex types like `List[Tuple[float,float]]` by monkey-patching `scabha.validate.validate_parameters` to add string-to-complex-type coercion
- When `{recipe.kernel}` is used, Python's string formatter stringifies the value (e.g. `"[(1.0, 2.0), (3.0, 4.0)]"`); the patch parses it back via `ast.literal_eval` / `yaml.safe_load` before pydantic validation
- Adds 22 tests covering the core bug, other composite types, regression checks, file types, and edge cases

## Test plan

- [x] New tests in `tests/test_complex_type_coercion.py` (22 tests, all passing)
- [x] Existing test suite passes (81 tests, excluding pre-existing `test_test_recipe` failure due to `/bin/true` not existing on macOS)
- [x] Ruff lint and format clean

Fixes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)