### PR TITLE
Improve error message when CLI assignment conflicts with None section

### DIFF
--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -32,6 +32,28 @@ from stimela.kitchen.recipe import Recipe, RecipeSchema, Step
 from stimela.kitchen.run_state import graph_to_constraints
 
 
+def _report_none_section_conflict(params, log):
+    """Check params dict for cases where a key is set to None and a subsequent key tries
+    to set a nested value under it. Logs a detailed warning for each conflict found.
+
+    For example, if params has {"foo.bar": None, "foo.bar.baz": 1}, the first entry
+    sets foo.bar to None, and the second tries to create a nested namespace under it,
+    which will fail with a confusing TypeError from SubstitutionNS.
+    """
+    none_keys = {k for k, v in params.items() if v is None}
+    for none_key in sorted(none_keys):
+        prefix = none_key + "."
+        conflicts = [k for k in params if k.startswith(prefix)]
+        if conflicts:
+            log.error(
+                f"parameter '{none_key}' is set to None (possibly from an empty YAML section "
+                f"in a parameter file), but the following assignments try to set nested values "
+                f"under it: {', '.join(repr(c) for c in conflicts)}. "
+                f"Either remove the empty section for '{none_key.split('.')[-1]}' from the "
+                f"parameter file, or give it explicit content (e.g. '{none_key.split('.')[-1]}: {{}}')"
+            )
+
+
 def resolve_recipe_files(filename: str, log: logging.Logger, use_manifest: bool = True):
     """
     Resolves a recipe file, which may be specified as (module)recipe.yml or module::recipe.yml, with
@@ -525,7 +547,22 @@ def run(
     subst._add_("info", info)
     subst._add_("self", info)
     subst._add_("config", stimela.CONFIG, nosubst=True)
-    subst._add_("current", SubstitutionNS(**params))
+    try:
+        subst._add_("current", SubstitutionNS(**params))
+    except TypeError as exc:
+        # This can happen when a parameter file sets a section to None (e.g. an empty YAML
+        # mapping value like "procres:" with nothing after it), and a subsequent assignment
+        # tries to set a dotted key under that section (e.g. "procres.foo=bar").
+        _report_none_section_conflict(params, log)
+        log_exception(
+            f"error processing parameter assignments: {exc}. "
+            "This typically happens when a parameter file contains an empty section "
+            "(e.g. 'section:' with no value), which sets it to None, and a subsequent "
+            "assignment tries to set a nested key under it (e.g. 'section.key=value'). "
+            "To fix this, either remove the empty section from the parameter file, or "
+            "give it an explicit value (e.g. 'section: " + "{}')."
+        )
+        sys.exit(2)
 
     # are we running a standalone cab?
     if cab_name is not None:
@@ -587,8 +624,19 @@ def run(
         for key, value in params.items():
             try:
                 recipe.assign_value(key, value, override=True)
-            except ScabhaBaseException as exc:
-                log_exception(exc)
+            except (ScabhaBaseException, TypeError) as exc:
+                if isinstance(exc, TypeError) and "not a nested namespace" in str(exc):
+                    _report_none_section_conflict(params, log)
+                    log_exception(
+                        f"error assigning {key}={value}: {exc}. "
+                        "This typically happens when a parameter file contains an empty section "
+                        "(e.g. 'section:' with no value), which sets it to None, and a subsequent "
+                        "assignment tries to set a nested key under it (e.g. 'section.key=value'). "
+                        "To fix this, either remove the empty section from the parameter file, or "
+                        "give it an explicit value (e.g. 'section: " + "{}')."
+                    )
+                else:
+                    log_exception(exc)
                 sys.exit(1)
 
         # create subst namespace for outer step

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -387,6 +387,18 @@ class Step:
                 self.cargo.assign_value(key, value, override=override)
             except ScabhaBaseException as exc:
                 raise AssignmentError(f"{self.name}: invalid assignment {key}={value}", exc)
+            except TypeError as exc:
+                if "not a nested namespace" in str(exc):
+                    # Provide a clearer error when a None value blocks nested assignment
+                    parts = key.split(".")
+                    raise AssignmentError(
+                        f"{self.name}: can't assign {key}={value}: {exc}. "
+                        f"This typically happens when '{parts[0]}' was set to None "
+                        f"(e.g. from an empty YAML section in a parameter file). "
+                        f"Either remove the empty section or give it explicit content "
+                        f"(e.g. '{parts[0]}: {{}}')"
+                    )
+                raise
 
     def build(self, backend=None, rebuild=False, build_skips=False, log: Optional[logging.Logger] = None):
         # skipping step? ignore the build

--- a/tests/param_file_none_section.yml
+++ b/tests/param_file_none_section.yml
@@ -1,0 +1,9 @@
+stringy: "A string!"
+listy:
+  - "A"
+  - "list"
+  - "!"
+
+# This empty section produces a None value, which should cause a clear error
+# when a CLI assignment tries to set a nested key under it (e.g. echo-inputs.extra=foo)
+echo-inputs:

--- a/tests/test_param_file.py
+++ b/tests/test_param_file.py
@@ -1,5 +1,15 @@
+import subprocess
+
 from .test_recipe import change_test_dir as change_test_dir
 from .test_recipe import run, verify_output
+
+
+def run_with_stderr(command):
+    """Runs command, returns tuple of exit code, combined stdout+stderr output"""
+    print(f"running: {command}")
+    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+    combined = result.stdout + result.stderr
+    return result.returncode, combined.strip()
 
 
 def test_param_file_input():
@@ -10,3 +20,19 @@ def test_param_file_input():
     assert verify_output(output, "A string!", "['A', 'list', '!']")
     assert not verify_output(output, "gremlin")
     assert verify_output(output, "Found a unicorn!")
+
+
+def test_param_file_none_section_error_message():
+    """Test that a parameter file with an empty section (None value) followed by a
+    CLI assignment to a nested key under that section produces a clear error message
+    rather than a cryptic 'not a nested namespace' TypeError. (Issue #552)
+    """
+    print("===== expecting a clear error about None section =====")
+    retcode, output = run_with_stderr(
+        "stimela -b native run test_param_file.yml test-param-file "
+        "-pf param_file_none_section.yml echo-inputs.extra=unicorn"
+    )
+    assert retcode != 0
+    print(output)
+    # The error message should mention the empty section / None value problem
+    assert verify_output(output, "empty section") or verify_output(output, "set to None")


### PR DESCRIPTION
## Summary
- Fixes #552
- When a parameter file contains an empty YAML section (e.g. `procres:` with no value), it is parsed as `None`. If a subsequent CLI assignment tries to set a nested key under that section (e.g. `procres.selfnoise-scaling-factor=2`), the error was a cryptic `TypeError: can't insert 'procres.selfnoise-scaling-factor': procres is not a nested namespace`.
- This PR catches the error at three levels (`SubstitutionNS` construction, `recipe.assign_value`, and `step.assign_value`) and provides a clear message identifying which parameter is set to `None`, which assignments conflict, and how to fix it (remove the empty section or use `section: {}`).
- Adds a test that verifies the improved error message is shown.

## Test plan
- [x] `uv run pytest tests/test_param_file.py` -- both tests pass (existing + new)
- [x] `uv run pytest tests/test_recipe.py::test_test_aliasing tests/test_recipe.py::test_test_nesting` -- no regressions
- [x] `uv run ruff check` and `uv run ruff format --check` pass
- [x] Manually verified error output shows the improved message

🤖 Generated with [Claude Code](https://claude.com/claude-code)