### PR TITLE
Fix kube backend: metrics server and PVC deletion

### DIFF
--- a/stimela/backends/kube/infrastructure.py
+++ b/stimela/backends/kube/infrastructure.py
@@ -351,11 +351,14 @@ def delete_pvcs(
                 resp = kube_api.delete_namespaced_persistent_volume_claim(name=pvc.name, namespace=namespace)
             except ApiException as exc:
                 body = json.loads(exc.body)
-                log_exception(
-                    BackendError(f"k8s API error while deleting PVC '{pvc.name}'", (exc, body)),
-                    severity="error",
-                    log=log,
-                )
+                if exc.status == 404:
+                    log.warning(f"PVC '{pvc.name}' not found (404), it may have already been deleted")
+                else:
+                    log_exception(
+                        BackendError(f"k8s API error while deleting PVC '{pvc.name}'", (exc, body)),
+                        severity="error",
+                        log=log,
+                    )
                 continue
             log.debug(f"delete_namespaced_persistent_volume_claim({pvc.name}): {resp}")
             pvc.status = "Terminating"

--- a/stimela/backends/kube/kube_utils.py
+++ b/stimela/backends/kube/kube_utils.py
@@ -241,6 +241,8 @@ class StatusReporter(object):
                     )
                 except ApiException as exc:
                     self.report_api_error("metrics.k8s.io", exc)
+                    # disable metrics collection if metrics server is not available
+                    self.enable_metrics = False
         except (ConnectionError, HTTPError):
             self.connected = False
             # self.log.warning(f"disconnected: {exc}")

--- a/stimela/display/styles/kube.py
+++ b/stimela/display/styles/kube.py
@@ -159,26 +159,33 @@ class KubeDisplay(DisplayStyle):
 
         self.kube_connection_status.update(self.kube_connection_status_id, value=f"{report.connection_status}")
 
-        cpu_percent = report.total_cores * 100
+        if report.total_cores is not None:
+            cpu_percent = report.total_cores * 100
+            self.kube_core_usage.update(self.kube_core_usage_id, value=f"[green]{cpu_percent:2.1f}[/green]%")
+            max_cpu_percent = max(cpu_percent, self.task_maxima["kube_peak_core_usage"])
+            self.task_maxima["kube_peak_core_usage"] = max_cpu_percent
+            self.kube_peak_core_usage.update(
+                self.kube_peak_core_usage_id, value=f"[green]{max_cpu_percent:2.1f}[/green]%"
+            )
 
-        self.kube_core_usage.update(self.kube_core_usage_id, value=f"[green]{cpu_percent:2.1f}[/green]%")
+        if report.total_memory is not None:
+            self.kube_ram_usage.update(self.kube_ram_usage_id, value=f"[green]{report.total_memory}[/green]GB")
+            max_ram = max(report.total_memory, self.task_maxima["kube_peak_ram_usage"])
+            self.task_maxima["kube_peak_ram_usage"] = max_ram
+            self.kube_peak_ram_usage.update(self.kube_peak_ram_usage_id, value=f"[green]{max_ram}[/green]GB")
 
-        max_cpu_percent = max(cpu_percent, self.task_maxima["kube_peak_core_usage"])
-        self.task_maxima["kube_peak_core_usage"] = max_cpu_percent
-        self.kube_peak_core_usage.update(self.kube_peak_core_usage_id, value=f"[green]{max_cpu_percent:2.1f}[/green]%")
-
-        self.kube_ram_usage.update(self.kube_ram_usage_id, value=f"[green]{report.total_memory}[/green]GB")
-
-        max_ram = max(report.total_memory, self.task_maxima["kube_peak_ram_usage"])
-        self.task_maxima["kube_peak_ram_usage"] = max_ram
-        self.kube_peak_ram_usage.update(self.kube_peak_ram_usage_id, value=f"[green]{max_ram}[/green]GB")
-
-        self.pending_pods.update(self.pending_pods_id, value=f"[yellow]{report.pending_pods}[/yellow]")
-        self.running_pods.update(self.running_pods_id, value=f"[green]{report.running_pods}[/green]")
-        self.terminating_pods.update(self.terminating_pods_id, value=f"[blue]{report.terminating_pods}[/blue]")
-        self.successful_pods.update(self.successful_pods_id, value=f"[green]{report.successful_pods}[/green]")
-        self.failed_pods.update(self.failed_pods_id, value=f"[red]{report.failed_pods}[/red]")
-        self.stateless_pods.update(self.stateless_pods_id, value=f"[red]{report.stateless_pods}[/red]")
+        if report.pending_pods is not None:
+            self.pending_pods.update(self.pending_pods_id, value=f"[yellow]{report.pending_pods}[/yellow]")
+        if report.running_pods is not None:
+            self.running_pods.update(self.running_pods_id, value=f"[green]{report.running_pods}[/green]")
+        if report.terminating_pods is not None:
+            self.terminating_pods.update(self.terminating_pods_id, value=f"[blue]{report.terminating_pods}[/blue]")
+        if report.successful_pods is not None:
+            self.successful_pods.update(self.successful_pods_id, value=f"[green]{report.successful_pods}[/green]")
+        if report.failed_pods is not None:
+            self.failed_pods.update(self.failed_pods_id, value=f"[red]{report.failed_pods}[/red]")
+        if report.stateless_pods is not None:
+            self.stateless_pods.update(self.stateless_pods_id, value=f"[red]{report.stateless_pods}[/red]")
 
 
 class SimpleKubeDisplay(DisplayStyle):
@@ -280,10 +287,16 @@ class SimpleKubeDisplay(DisplayStyle):
             return
 
         self.kube_connection_status.update(self.kube_connection_status_id, value=f"{report.connection_status}")
-        cpu_percent = report.total_cores * 100
-        self.kube_core_usage.update(self.kube_core_usage_id, value=f"[green]{cpu_percent:2.1f}[/green]%")
-        self.kube_ram_usage.update(self.kube_ram_usage_id, value=f"[green]{report.total_memory}[/green]GB")
-        self.pending_pods.update(self.pending_pods_id, value=f"[yellow]{report.pending_pods}[/yellow]")
-        self.running_pods.update(self.running_pods_id, value=f"[cyan]{report.running_pods}[/cyan]")
-        self.successful_pods.update(self.successful_pods_id, value=f"[green]{report.successful_pods}[/green]")
-        self.failed_pods.update(self.failed_pods_id, value=f"[red]{report.failed_pods}[/red]")
+        if report.total_cores is not None:
+            cpu_percent = report.total_cores * 100
+            self.kube_core_usage.update(self.kube_core_usage_id, value=f"[green]{cpu_percent:2.1f}[/green]%")
+        if report.total_memory is not None:
+            self.kube_ram_usage.update(self.kube_ram_usage_id, value=f"[green]{report.total_memory}[/green]GB")
+        if report.pending_pods is not None:
+            self.pending_pods.update(self.pending_pods_id, value=f"[yellow]{report.pending_pods}[/yellow]")
+        if report.running_pods is not None:
+            self.running_pods.update(self.running_pods_id, value=f"[cyan]{report.running_pods}[/cyan]")
+        if report.successful_pods is not None:
+            self.successful_pods.update(self.successful_pods_id, value=f"[green]{report.successful_pods}[/green]")
+        if report.failed_pods is not None:
+            self.failed_pods.update(self.failed_pods_id, value=f"[red]{report.failed_pods}[/red]")

--- a/stimela/monitoring/kube.py
+++ b/stimela/monitoring/kube.py
@@ -21,4 +21,9 @@ class KubeReport:
 
     @property
     def profiling_results(self):
-        return {"k8s_cores": self.total_cores, "k8s_mem": self.total_memory}
+        results = {}
+        if self.total_cores is not None:
+            results["k8s_cores"] = self.total_cores
+        if self.total_memory is not None:
+            results["k8s_mem"] = self.total_memory
+        return results

--- a/tests/test_kube_graceful_degradation.py
+++ b/tests/test_kube_graceful_degradation.py
@@ -1,0 +1,243 @@
+"""Tests for kube backend graceful degradation.
+
+Covers:
+- Issue #504: metrics server absence should not break the stat reporter/display
+- Issue #301: PVC deletion should handle 404 errors gracefully
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from stimela.monitoring.kube import KubeReport
+
+# ---------------------------------------------------------------------------
+# Issue #504 – KubeReport.profiling_results with None metrics
+# ---------------------------------------------------------------------------
+
+
+class TestKubeReportProfilingResults:
+    """KubeReport.profiling_results must tolerate None metric values."""
+
+    def test_profiling_results_with_values(self):
+        report = KubeReport(total_cores=2.5, total_memory=16.0)
+        result = report.profiling_results
+        assert result == {"k8s_cores": 2.5, "k8s_mem": 16.0}
+
+    def test_profiling_results_without_metrics(self):
+        """When no metrics server is present, total_cores and total_memory are None."""
+        report = KubeReport()
+        result = report.profiling_results
+        # None values must be excluded so downstream arithmetic doesn't break
+        assert "k8s_cores" not in result
+        assert "k8s_mem" not in result
+        assert result == {}
+
+    def test_profiling_results_partial_metrics(self):
+        """Only non-None metrics should appear in the result."""
+        report = KubeReport(total_cores=1.0)
+        result = report.profiling_results
+        assert result == {"k8s_cores": 1.0}
+        assert "k8s_mem" not in result
+
+        report = KubeReport(total_memory=8.0)
+        result = report.profiling_results
+        assert result == {"k8s_mem": 8.0}
+        assert "k8s_cores" not in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #504 – Display classes handle None metrics gracefully
+# ---------------------------------------------------------------------------
+
+
+class TestKubeDisplayNoneMetrics:
+    """Display update methods must not crash when report fields are None."""
+
+    def test_kube_display_update_with_none_metrics(self):
+        """KubeDisplay.update should not raise when total_cores/total_memory are None."""
+        from stimela.display.styles.kube import KubeDisplay
+
+        # Create a minimal KubeDisplay by mocking the Progress dependency
+        with patch("stimela.display.styles.kube.timer_element") as mock_timer:
+            mock_progress = MagicMock()
+            mock_progress.columns = [MagicMock(), MagicMock()]
+            mock_progress.columns[1].get_table_column.return_value = MagicMock()
+            mock_progress.add_task.return_value = 0
+            mock_timer.return_value = mock_progress
+
+            display = KubeDisplay(mock_progress)
+
+        # Report with no metrics (simulates missing metrics server)
+        report = KubeReport(
+            running_pods=1,
+            pending_pods=0,
+            terminating_pods=0,
+            successful_pods=0,
+            failed_pods=0,
+            stateless_pods=0,
+            total_pods=1,
+            # total_cores and total_memory intentionally left as None
+        )
+
+        task_info = MagicMock()
+        task_info.description = "test"
+        task_info.status = "running"
+        task_info.command = "echo hello"
+
+        # This must not raise TypeError
+        display.update(task_info, report)
+
+    def test_simple_kube_display_update_with_none_metrics(self):
+        """SimpleKubeDisplay.update should not raise when total_cores/total_memory are None."""
+        from stimela.display.styles.kube import SimpleKubeDisplay
+
+        mock_progress = MagicMock()
+        mock_progress.columns = [MagicMock(), MagicMock()]
+        mock_progress.add_task.return_value = 0
+
+        with patch("stimela.display.styles.kube.timer_element") as mock_timer:
+            mock_timer.return_value = mock_progress
+            display = SimpleKubeDisplay(mock_progress)
+
+        report = KubeReport()  # All None except connection_status
+
+        task_info = MagicMock()
+        task_info.description = "test"
+        task_info.command = "echo hello"
+
+        # This must not raise TypeError
+        display.update(task_info, report)
+
+
+# ---------------------------------------------------------------------------
+# Issue #301 – PVC deletion handles 404 gracefully
+# ---------------------------------------------------------------------------
+
+
+def _import_infrastructure():
+    """Import the infrastructure module, which requires the kube backend to be loadable.
+
+    The kube __init__ tries to load kubernetes config at module level. We need to
+    ensure the module is importable even without a real kube config by pre-importing
+    stimela.backends.kube first (which gracefully handles missing kubernetes).
+    """
+    # Ensure the parent kube package is loaded
+    import stimela.backends.kube  # noqa: F401
+
+    # Now import the infrastructure submodule
+    from stimela.backends.kube import infrastructure
+
+    return infrastructure
+
+
+try:
+    import kubernetes  # noqa: F401
+
+    HAS_KUBERNETES = True
+except ImportError:
+    HAS_KUBERNETES = False
+
+
+@pytest.mark.skipif(not HAS_KUBERNETES, reason="kubernetes package not installed")
+class TestPvcDeletion404:
+    """delete_pvcs should log a warning (not an error) on 404 ApiException."""
+
+    def test_delete_pvc_404_logs_warning(self):
+        from kubernetes.client.rest import ApiException
+
+        from stimela.backends.kube import KubeBackendOptions
+
+        infrastructure = _import_infrastructure()
+        Lifecycle = KubeBackendOptions.Volume.Lifecycle
+
+        # Set up mock k8s API
+        mock_kube_api = MagicMock()
+
+        # Simulate 404 on PVC deletion
+        body_404 = json.dumps(
+            {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "status": "Failure",
+                "message": 'persistentvolumeclaims "test-pvc-abc123" not found',
+                "reason": "NotFound",
+                "code": 404,
+            }
+        )
+        exc = ApiException(status=404, reason="Not Found")
+        exc.body = body_404
+        mock_kube_api.delete_namespaced_persistent_volume_claim.side_effect = exc
+
+        # Set up a PVC in active_pvcs
+        pvc = KubeBackendOptions.Volume(
+            name="test-pvc-abc123",
+            capacity="10Gi",
+            lifecycle=Lifecycle.step,
+        )
+        pvc.status = "Bound"
+        infrastructure.active_pvcs["test-vol"] = pvc
+
+        kube = MagicMock()
+        log = MagicMock()
+
+        try:
+            with patch.object(infrastructure, "get_kube_api", return_value=("test-ns", mock_kube_api, MagicMock())):
+                with patch.object(infrastructure, "refresh_pvc_list"):
+                    infrastructure.delete_pvcs(kube, ["test-vol"], log=log, step=True, refresh=False)
+
+            # Verify warning was logged, not error
+            log.warning.assert_called_once()
+            warning_msg = log.warning.call_args[0][0]
+            assert "not found" in warning_msg.lower() or "404" in warning_msg
+        finally:
+            # Clean up module-level state
+            infrastructure.active_pvcs.pop("test-vol", None)
+
+    def test_delete_pvc_other_error_logs_error(self):
+        """Non-404 ApiException during PVC deletion should still log as error."""
+        from kubernetes.client.rest import ApiException
+
+        from stimela.backends.kube import KubeBackendOptions
+
+        infrastructure = _import_infrastructure()
+        Lifecycle = KubeBackendOptions.Volume.Lifecycle
+
+        mock_kube_api = MagicMock()
+
+        # Simulate 500 error
+        body_500 = json.dumps(
+            {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "status": "Failure",
+                "message": "Internal server error",
+                "reason": "InternalError",
+                "code": 500,
+            }
+        )
+        exc = ApiException(status=500, reason="Internal Server Error")
+        exc.body = body_500
+        mock_kube_api.delete_namespaced_persistent_volume_claim.side_effect = exc
+
+        pvc = KubeBackendOptions.Volume(
+            name="test-pvc-xyz789",
+            capacity="10Gi",
+            lifecycle=Lifecycle.step,
+        )
+        pvc.status = "Bound"
+        infrastructure.active_pvcs["test-vol-err"] = pvc
+
+        kube = MagicMock()
+        log = MagicMock()
+
+        try:
+            with patch.object(infrastructure, "get_kube_api", return_value=("test-ns", mock_kube_api, MagicMock())):
+                with patch.object(infrastructure, "refresh_pvc_list"):
+                    infrastructure.delete_pvcs(kube, ["test-vol-err"], log=log, step=True, refresh=False)
+
+            # 500 errors should NOT be logged as warnings
+            log.warning.assert_not_called()
+        finally:
+            infrastructure.active_pvcs.pop("test-vol-err", None)


### PR DESCRIPTION
## Summary
- **#504**: The kube backend assumed a metrics server exists. When absent, `KubeReport.total_cores` and `total_memory` are `None`, causing `TypeError` in display updates and stats collection. Fixed by adding `None` guards in both display classes (`KubeDisplay`, `SimpleKubeDisplay`), filtering `None` values from `KubeReport.profiling_results`, and disabling metrics polling after the first API error.
- **#301**: PVC deletion occasionally hits a 404 `ApiException` when a PVC has already been removed (e.g. by k8s lifecycle management). Previously logged as an error with a full stack trace. Now catches 404 specifically and logs a simple warning instead.

## Changes
- `stimela/monitoring/kube.py` -- `KubeReport.profiling_results` excludes `None` metrics
- `stimela/display/styles/kube.py` -- Both `KubeDisplay.update()` and `SimpleKubeDisplay.update()` guard against `None` report fields
- `stimela/backends/kube/kube_utils.py` -- `StatusReporter.update()` disables metrics after first API error
- `stimela/backends/kube/infrastructure.py` -- `delete_pvcs()` catches 404 and logs warning instead of error
- `tests/test_kube_graceful_degradation.py` -- 7 new unit tests covering both fixes

## Test plan
- [x] `KubeReport.profiling_results` returns empty dict when metrics are `None`
- [x] `KubeReport.profiling_results` includes only non-`None` metrics (partial)
- [x] `KubeDisplay.update()` does not crash with `None` metrics
- [x] `SimpleKubeDisplay.update()` does not crash with `None` metrics
- [x] PVC deletion 404 logs warning (requires `kubernetes` package, skipped in CI if unavailable)
- [x] PVC deletion non-404 error still logs as error
- [x] Full test suite passes (pre-existing `test_test_recipe` failure unrelated)

Closes #504, closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)