### PR TITLE
Fix missing parameter error for non-required outputs

### DIFF
--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -1286,7 +1286,8 @@ class Recipe(Cargo):
         for name, schema in self.inputs.items():
             if name in params:
                 value = params[name]
-                if isinstance(value, Unresolved) and not isinstance(value, Placeholder):
+                is_unresolved = isinstance(value, Unresolved) and not isinstance(value, Placeholder)
+                if is_unresolved and schema.required is not False:
                     raise RecipeValidationError(f"recipe '{self.name}' has unresolved input '{name}'", log=self.log)
                 self._update_aliases(name, value)
             elif schema.required and (self.for_loop is None or name != self.for_loop.var):

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -596,7 +596,7 @@ class Step:
             invalid = self.invalid_params
             for name in self.unresolved_params:
                 schema = self.cargo.inputs_outputs[name]
-                if schema.is_input or schema.is_named_output:
+                if (schema.is_input or schema.is_named_output) and schema.required is not False:
                     invalid.append(name)
             if invalid:
                 if skip:

--- a/tests/test_issue324.yml
+++ b/tests/test_issue324.yml
@@ -1,0 +1,27 @@
+cabs:
+  echo:
+    command: echo
+    inputs:
+      msg:
+        dtype: str
+        required: true
+        policies:
+          positional: true
+    outputs:
+      temp-dir:
+        dtype: Directory
+        skip_freshness_checks: true
+        mkdir: true
+        must_exist: false
+        required: false
+
+recipe:
+  inputs:
+    msg:
+      dtype: str
+      default: "hello"
+  steps:
+    echo-1:
+      cab: echo
+      params:
+        msg: =recipe.msg

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -157,3 +157,12 @@ def test_scatter():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml nested_loop")
     assert retcode == 0
+
+
+def test_issue324():
+    """Test that non-required outputs do not cause errors when unresolved"""
+    print("===== expecting no errors for non-required output =====")
+    retcode, output = run("stimela -v -b native exec test_issue324.yml recipe")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "recipe .recipe. executed successfully")

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -165,4 +165,4 @@ def test_issue324():
     retcode, output = run("stimela -v -b native exec test_issue324.yml recipe")
     assert retcode == 0
     print(output)
-    assert verify_output(output, "recipe .recipe. executed successfully")
+    assert verify_output(output, "recipe 'recipe' executed successfully")


### PR DESCRIPTION
## Summary
- Non-required outputs (e.g. `required: false` on a Directory output) were incorrectly raising "invalid inputs" errors when their values were unresolved
- Added `schema.required is not False` check to the input validation path in `step.py` (matching the existing pattern in the output validation path)
- Also fixed the same issue in `recipe.py` where unresolved non-required inputs raised errors during alias propagation

## Test plan
- [x] Added `test_issue324` test with a cab that has a non-required Directory output
- [x] Verified test passes: recipe executes successfully without spurious errors
- [x] Existing tests pass (pre-existing `test_test_recipe` failure unrelated)

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)