### PR TITLE
Fix confusing error for conflicting dotted parameter assignments

### DIFF
--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -602,7 +602,7 @@ def run(
             except ScabhaBaseException as exc:
                 log_exception(exc)
                 sys.exit(1)
-            except (TypeError, KeyError, AttributeError) as exc:
+            except (TypeError, KeyError) as exc:
                 log_exception(
                     RecipeValidationError(
                         f"error assigning '{key}={value}': {exc}. "

--- a/stimela/commands/run.py
+++ b/stimela/commands/run.py
@@ -525,7 +525,19 @@ def run(
     subst._add_("info", info)
     subst._add_("self", info)
     subst._add_("config", stimela.CONFIG, nosubst=True)
-    subst._add_("current", SubstitutionNS(**params))
+    try:
+        subst._add_("current", SubstitutionNS(**params))
+    except TypeError as exc:
+        log_exception(
+            RecipeValidationError(
+                f"conflicting parameter assignments: {exc}. "
+                f"This typically happens when one assignment sets a parameter to a scalar value "
+                f"(e.g. 'foo=null') while another tries to use it as a namespace prefix "
+                f"(e.g. 'foo.bar=value'). "
+                f"Please check your parameter assignments for conflicts."
+            )
+        )
+        sys.exit(1)
 
     # are we running a standalone cab?
     if cab_name is not None:
@@ -589,6 +601,15 @@ def run(
                 recipe.assign_value(key, value, override=True)
             except ScabhaBaseException as exc:
                 log_exception(exc)
+                sys.exit(1)
+            except (TypeError, KeyError, AttributeError) as exc:
+                log_exception(
+                    RecipeValidationError(
+                        f"error assigning '{key}={value}': {exc}. "
+                        f"Check that '{key}' refers to a valid parameter or step, "
+                        f"and that intermediate dotted components are sections rather than scalar values."
+                    )
+                )
                 sys.exit(1)
 
         # create subst namespace for outer step

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -216,7 +216,15 @@ class Recipe(Cargo):
             # drop entries protected from assignment
             flattened = {name: value for name, value in flattened.items() if name not in self._protected_from_assign}
             # merge into recipe namespace
-            subst.recipe._merge_(flattened)
+            try:
+                subst.recipe._merge_(flattened)
+            except TypeError as exc:
+                raise AssignmentError(
+                    f"{whose.fqname}: error merging assignments into recipe namespace. "
+                    f"A dotted key (e.g. 'a.b.c=value') conflicts with an existing non-section value. "
+                    f"Check that intermediate keys in your assignments are not set to None or scalar values.",
+                    exc,
+                )
             # perform substitutions
             try:
                 flattened = evaluate_and_substitute(
@@ -327,7 +335,15 @@ class Recipe(Cargo):
             while len(comps) > 1:
                 if comps[0] not in container:
                     raise AssignmentError(f"{self.fqname}: invalid assignment {key}={value}")
-                container = container[comps[0]]
+                next_container = container[comps[0]]
+                if next_container is None or not hasattr(next_container, "__getitem__"):
+                    raise AssignmentError(
+                        f"{self.fqname}: can't assign '{key}={value}': '{comps[0]}' is not a nested section "
+                        f"(its current value is {next_container!r}). "
+                        f"Check your parameter assignments for typos, or ensure that '{comps[0]}' is defined as a "
+                        f"mapping/section rather than a scalar value."
+                    )
+                container = next_container
                 comps.pop(0)
             container[comps[0]] = value
 
@@ -848,7 +864,17 @@ class Recipe(Cargo):
                 errors.append(RecipeValidationError("recipe failed prevalidation", exc, tb=True))
 
             # merge again, since values may have changed
-            subst.recipe._merge_(params)
+            try:
+                subst.recipe._merge_(params)
+            except TypeError as exc:
+                errors.append(
+                    RecipeValidationError(
+                        f"error merging parameters into recipe namespace. "
+                        f"A dotted parameter name conflicts with an existing non-section value. "
+                        f"Check that intermediate keys in your parameter names are not set to None or scalar values: "
+                        f"{exc}",
+                    )
+                )
             if root:
                 subst.root = subst.recipe
             return params

--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -336,7 +336,7 @@ class Recipe(Cargo):
                 if comps[0] not in container:
                     raise AssignmentError(f"{self.fqname}: invalid assignment {key}={value}")
                 next_container = container[comps[0]]
-                if next_container is None or not hasattr(next_container, "__getitem__"):
+                if next_container is None or not isinstance(next_container, Mapping):
                     raise AssignmentError(
                         f"{self.fqname}: can't assign '{key}={value}': '{comps[0]}' is not a nested section "
                         f"(its current value is {next_container!r}). "

--- a/stimela/kitchen/step.py
+++ b/stimela/kitchen/step.py
@@ -784,7 +784,14 @@ class Step:
             if validated:
                 self.validated_params.update(**params)
                 if subst is not None:
-                    subst.current._merge_(params)
+                    try:
+                        subst.current._merge_(params)
+                    except TypeError as exc:
+                        raise StepValidationError(
+                            f"error merging parameters into namespace for step '{self.fqname}'. "
+                            f"A dotted parameter name conflicts with an existing non-section value: {exc}",
+                            log=self.log,
+                        )
                 self.log_summary(logging.DEBUG, "validated outputs", ignore_missing=True, outputs=True)
 
             if self.evaluate_section("epilogue", subst):

--- a/tests/test_issue552.yml
+++ b/tests/test_issue552.yml
@@ -1,0 +1,45 @@
+cabs:
+  echo:
+    command: echo
+    inputs:
+      message:
+        dtype: str
+        default: hello
+
+# Recipes for testing issue #552:
+# Dotted CLI parameter assignments that conflict with existing values.
+
+recipe_with_none_assign:
+  name: "issue 552 recipe"
+  info: "Recipe where assign sets procres to null"
+  assign:
+    procres: null
+  steps:
+    step1:
+      cab: echo
+      params:
+        message: "step1 says hello"
+
+recipe_with_scalar_assign:
+  name: "issue 552 scalar recipe"
+  info: "Recipe where assign sets procres to a scalar"
+  assign:
+    procres: "some_scalar_value"
+  steps:
+    step1:
+      cab: echo
+      params:
+        message: "step1 says hello"
+
+simple_recipe:
+  name: "simple recipe"
+  info: "A simple recipe for basic assignment testing"
+  inputs:
+    msg:
+      dtype: str
+      default: "hello"
+  steps:
+    step1:
+      cab: echo
+      params:
+        message: "{recipe.msg}"

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -189,8 +189,8 @@ def test_issue552_recipe_assign_conflict():
     retcode, output = run(
         "stimela -v -b native run test_issue552.yml recipe_with_none_assign procres.selfnoise-scaling-factor=2"
     )
-    # This actually succeeds because override protection prevents the conflict.
-    # Just verify it doesn't crash with a raw TypeError.
+    # Override protection prevents the conflict, so this should succeed.
+    assert retcode == 0, f"Expected success but got retcode {retcode}"
     print(output)
     assert "TypeError" not in output
 

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -157,3 +157,47 @@ def test_scatter():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml nested_loop")
     assert retcode == 0
+
+
+def test_issue552_conflicting_cli_params_none():
+    """Test that conflicting CLI params (scalar + dotted sub-key) give a clear error, not a raw TypeError."""
+    print("===== expecting a clear error when CLI params conflict (None + dotted) =====")
+    retcode, output = run(
+        "stimela -v -b native run test_issue552.yml simple_recipe procres=null procres.selfnoise-scaling-factor=2"
+    )
+    assert retcode != 0
+    print(output)
+    # Should get a clear error about conflicting assignments, not a raw TypeError
+    assert verify_output(output, "conflicting parameter assignments")
+
+
+def test_issue552_conflicting_cli_params_scalar():
+    """Test that conflicting CLI params (string scalar + dotted sub-key) give a clear error."""
+    print("===== expecting a clear error when CLI params conflict (scalar + dotted) =====")
+    retcode, output = run(
+        "stimela -v -b native run test_issue552.yml simple_recipe procres=hello procres.selfnoise-scaling-factor=2"
+    )
+    assert retcode != 0
+    print(output)
+    # Should get a clear error about conflicting assignments, not a raw TypeError
+    assert verify_output(output, "conflicting parameter assignments")
+
+
+def test_issue552_recipe_assign_conflict():
+    """Test that a recipe with assign procres=null and CLI procres.x=2 provides a clear error."""
+    print("===== expecting a clear error when recipe assign conflicts with CLI dotted param =====")
+    retcode, output = run(
+        "stimela -v -b native run test_issue552.yml recipe_with_none_assign procres.selfnoise-scaling-factor=2"
+    )
+    # This actually succeeds because override protection prevents the conflict.
+    # Just verify it doesn't crash with a raw TypeError.
+    print(output)
+    assert "TypeError" not in output
+
+
+def test_issue552_simple_recipe_runs():
+    """Test that a simple recipe still runs fine after the fix."""
+    print("===== expecting no errors for simple recipe =====")
+    retcode, output = run("stimela -v -b native run test_issue552.yml simple_recipe msg=world")
+    assert retcode == 0
+    print(output)


### PR DESCRIPTION
## Summary
- Catches `TypeError` from `SubstitutionNS` operations when conflicting dotted parameter keys are used (e.g. `procres=null` alongside `procres.selfnoise-scaling-factor=2`)
- Converts raw `TypeError` messages into clear, actionable error messages in `run.py`, `recipe.py`, and `step.py`
- Also improves `assign_nested()` in `recipe.py` to detect when an intermediate key is `None` or a non-container value and raise a descriptive `AssignmentError`

## Test plan
- [x] Added `test_issue552_conflicting_cli_params_none` - verifies clear error when `procres=null` and `procres.x=2` are both passed
- [x] Added `test_issue552_conflicting_cli_params_scalar` - verifies clear error when `procres=hello` and `procres.x=2` are both passed
- [x] Added `test_issue552_recipe_assign_conflict` - verifies no raw `TypeError` when recipe assign has `procres: null` and CLI passes `procres.x=2`
- [x] Added `test_issue552_simple_recipe_runs` - regression test verifying normal recipe execution still works
- [x] Existing tests (aliasing, nesting, loops, issue527) all pass

Fixes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)