### PR TITLE
Fix nested assignments being silently ignored

### DIFF
--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -193,7 +193,9 @@ class Recipe(Cargo):
         if not whose.assign and not whose.assign_based_on:
             return
 
-        def flatten_dict(input_dict, output_dict={}, prefix=""):
+        def flatten_dict(input_dict, output_dict=None, prefix=""):
+            if output_dict is None:
+                output_dict = {}
             for name, value in input_dict.items():
                 name = f"{prefix}{name}"
                 if isinstance(value, (dict, OrderedDict, DictConfig)):
@@ -211,8 +213,8 @@ class Recipe(Cargo):
             Called repeatedly for the assign section, and for each assign_based_on entry. Substitution errors are
             ignored at this stage, a final round of re-evaluation with ignore=False is done at the end.
             """
-            # flatten assignments
-            flattened = assignments  # flatten_dict(assignments)
+            # flatten nested assignments (e.g. log: {name: foo} -> log.name: foo)
+            flattened = flatten_dict(assignments)
             # drop entries protected from assignment
             flattened = {name: value for name, value in flattened.items() if name not in self._protected_from_assign}
             # merge into recipe namespace

--- a/tests/test_nested_assign.yml
+++ b/tests/test_nested_assign.yml
@@ -1,0 +1,67 @@
+cabs:
+  echo:
+    image: null
+    command: echo
+    policies:
+      skip_implicits: true
+      key_value: true
+    inputs:
+      msg:
+        dtype: str
+        required: true
+
+opts:
+  log:
+    dir: test-logs/logs-{config.run.datetime}
+    nest: 3
+    symlink: logs
+
+# Test 1: nested assign with plain variables (available via {recipe.x.y})
+nested_assign_vars:
+  name: "nested assign vars"
+  assign:
+    myvar:
+      sub1: hello
+      sub2: world
+  steps:
+    echo-1:
+      cab: echo
+      params:
+        msg: "{recipe.myvar.sub1}-{recipe.myvar.sub2}"
+
+# Test 2: nested assign for log options
+nested_assign_log:
+  name: "nested assign log"
+  assign:
+    log:
+      name: custom-log-name
+  steps:
+    echo-1:
+      cab: echo
+      params:
+        msg: "test-log-assignment"
+
+# Test 3: nested assign to step params
+nested_assign_step:
+  name: "nested assign step"
+  steps:
+    echo-1:
+      cab: echo
+      assign:
+        log:
+          name: step-custom-log
+      params:
+        msg: "test-step-nested-assign"
+
+# Test 4: deeply nested assign
+nested_assign_deep:
+  name: "nested assign deep"
+  assign:
+    deep:
+      level1:
+        level2: deep-value
+  steps:
+    echo-1:
+      cab: echo
+      params:
+        msg: "{recipe.deep.level1.level2}"

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -149,6 +149,42 @@ def test_issue527_3():
     assert verify_output(output, "invalid inputs")
 
 
+def test_nested_assign_vars():
+    """Test that nested assignments create proper dotted variables (issue #467)"""
+    print("===== testing nested variable assignments =====")
+    retcode, output = run("stimela -v -b native exec test_nested_assign.yml nested_assign_vars")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "hello-world")
+
+
+def test_nested_assign_log():
+    """Test that nested log assignments are applied (issue #467)"""
+    print("===== testing nested log option assignments =====")
+    retcode, output = run("stimela -v -b native exec test_nested_assign.yml nested_assign_log")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "custom-log-name")
+
+
+def test_nested_assign_step_log():
+    """Test that nested step-level log assignments are applied (issue #467)"""
+    print("===== testing nested step-level log assignments =====")
+    retcode, output = run("stimela -v -b native exec test_nested_assign.yml nested_assign_step")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "step-custom-log")
+
+
+def test_nested_assign_deep():
+    """Test that deeply nested assignments work (issue #467)"""
+    print("===== testing deeply nested assignments =====")
+    retcode, output = run("stimela -v -b native exec test_nested_assign.yml nested_assign_deep")
+    assert retcode == 0
+    print(output)
+    assert verify_output(output, "deep-value")
+
+
 def test_scatter():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml basic_loop")


### PR DESCRIPTION
## Summary

- Fixes #467: Nested assignments in recipe `assign` blocks (e.g. `log: {name: foo}`) were silently ignored instead of being applied
- The root cause was that `flatten_dict()` in `do_assign()` was commented out, so nested dicts were passed through as-is to `assign_value()` which could not route them correctly
- Enabled the existing `flatten_dict()` call to convert nested dicts to dotted keys (e.g. `log.name: foo`) that `assign_value()` handles properly
- Also fixed a mutable default argument bug in `flatten_dict()`

## Test plan

- [x] Added 4 new tests covering nested variable assignments, nested log assignments, step-level log assignments, and deeply nested assignments
- [x] All existing tests pass (the pre-existing `test_test_recipe` failure on macOS due to `/bin/true` path is unrelated)
- [x] Ruff lint and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)