### PR TITLE
Reject unknown CLI parameters (fixes #530)

### DIFF
--- a/stimela/kitchen/recipe.py
+++ b/stimela/kitchen/recipe.py
@@ -356,6 +356,11 @@ class Recipe(Cargo):
             whose.update_log_options(**{subkey: value})
             if whose is self and subst is not None and "recipe" in subst:
                 subst.recipe.log[subkey] = value
+        elif override:
+            # In override mode (CLI parameters), unknown keys are an error.
+            # In non-override mode (recipe assign blocks), unknown keys are
+            # arbitrary recipe-level variables already handled by _do_assignments.
+            raise AssignmentError(f"{self.fqname}: '{key}' does not refer to a known parameter, step, or setting")
         # in override mode, assign to assign dict for future processing
         if override:
             if value is not UNSET:

--- a/tests/test_issue530.yml
+++ b/tests/test_issue530.yml
@@ -1,0 +1,21 @@
+cabs:
+  echo:
+    command: echo
+    inputs:
+      msg:
+        dtype: str
+        required: true
+        policies:
+          positional: true
+
+recipe:
+  inputs:
+    greeting:
+      dtype: str
+      default: hello
+
+  steps:
+    echo-1:
+      cab: echo
+      params:
+        msg: =recipe.greeting

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -149,6 +149,34 @@ def test_issue527_3():
     assert verify_output(output, "invalid inputs")
 
 
+def test_issue530_unknown_cli_params():
+    """Test that unknown CLI parameters are rejected (issue #530)"""
+    print("===== expecting an error for unknown recipe-level parameter =====")
+    retcode, output = run("stimela -v -b native exec test_issue530.yml nonexistent_param=bad")
+    assert retcode != 0
+    print(output)
+    assert verify_output(output, "does not refer to a known parameter")
+
+    print("===== expecting an error for unknown step-level parameter =====")
+    retcode, output = run("stimela -v -b native exec test_issue530.yml echo-1.nonexistent_param=bad")
+    assert retcode != 0
+    print(output)
+
+    print("===== expecting an error for assignment to a nonexistent step =====")
+    retcode, output = run("stimela -v -b native exec test_issue530.yml nonexistent_step.param=bad")
+    assert retcode != 0
+    print(output)
+    assert verify_output(output, "does not refer to a known parameter")
+
+    print("===== expecting success with valid parameters only =====")
+    retcode, output = run("stimela -v -b native exec test_issue530.yml greeting=world")
+    assert retcode == 0
+
+    print("===== expecting success with no extra parameters =====")
+    retcode, output = run("stimela -v -b native exec test_issue530.yml")
+    assert retcode == 0
+
+
 def test_scatter():
     print("===== expecting no errors now =====")
     retcode = os.system("stimela -v -b native exec test_scatter.yml basic_loop")


### PR DESCRIPTION
## Summary
- When users pass parameters on the command line that don't match any known recipe input/output, step name, config setting, or log option, stimela now raises an `AssignmentError` instead of silently ignoring them.
- This prevents the dangerous scenario described in #530 where typos in parameter names lead to wrong results with no warning.
- The check only applies to CLI override assignments. Recipe-level `assign:` blocks can still set arbitrary recipe namespace variables (existing intentional behavior).

## Changes
- `stimela/kitchen/recipe.py`: Added `elif override:` clause in `Recipe.assign_value()` that raises `AssignmentError` for unrecognized parameter keys passed from the CLI.
- `tests/test_issue530.yml`: New minimal test recipe for the issue.
- `tests/test_recipe.py`: New `test_issue530_unknown_cli_params` test covering unknown recipe-level params, unknown step-level params, nonexistent step names, and valid parameter usage.

## Test plan
- [x] Unknown recipe-level parameter (`nonexistent_param=bad`) raises error
- [x] Unknown step-level parameter (`echo-1.nonexistent_param=bad`) raises error  
- [x] Nonexistent step name (`nonexistent_step.param=bad`) raises error
- [x] Valid parameters still work correctly
- [x] Existing tests pass (aliasing, nesting, issue527, param_file, callables, conditional_skips)
- [x] Recipe-level `assign:` blocks with arbitrary variables still work (not affected by fix)

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)